### PR TITLE
feat (card): refactor Card to comply with strict linters

### DIFF
--- a/docs/weekly-reports/report.md
+++ b/docs/weekly-reports/report.md
@@ -27,6 +27,8 @@
 **Planning and Progress Tracking**:
 1. [done] Kevin: Added `CAT_CARDS` to the `CardType` enum and propagated to all dependent docs (`docs/design/design-doc.md` CardType list, `docs/bva/bva-Card.md` Method 2 Step 3 + new TC8). The parameterized `getCardType` test auto-picked up `CAT_CARDS` via `@EnumSource`; all 9 tests pass (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/24)
 2. [done] Kevin: Added `FAVOR` to the `CardType` enum and propagated to `docs/design/design-doc.md` and `docs/bva/bva-Card.md` (Method 2 Step 3 + new TC9). All 10 tests pass via `@EnumSource` auto-pickup (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/24)
+3. [done] Kevin: Set up Checkstyle (Google Java Style 10.18.2 base + project overrides for tab indent, no-Javadoc-required, `MagicNumber`, severity=error) and SpotBugs (default effort + confidence, HTML reports) as strict-mode quality gates wired into `./gradlew build`. PR's CI fails until each owner refactors their files on their own branch (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/25)
+4. [done] Kevin: Refactored `Card.java` (marked `final` to close SpotBugs `CT_CONSTRUCTOR_THROW` finalizer-attack vector) and `CardTest.java` (moved static imports above non-static to satisfy Checkstyle `CustomImportOrder` `STATIC###THIRD_PARTY_PACKAGE`) so the `Card` source files pass the strict linters from PR #25 (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/27)
 
 # Week X (XX/XX/2026-XX/XX/2026) TEMPLATE (You can change the format to whatever the team likes better)
 **Planning and Progress Tracking**:

--- a/src/main/java/domain/Card.java
+++ b/src/main/java/domain/Card.java
@@ -1,6 +1,6 @@
 package domain;
 
-public class Card {
+public final class Card {
 
 	private static final String NULL_CARD_TYPE_KEY = "card.nullType";
 

--- a/src/test/java/domain/CardTest.java
+++ b/src/test/java/domain/CardTest.java
@@ -1,11 +1,11 @@
 package domain;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CardTest {
 


### PR DESCRIPTION
## Summary
Refactor on `feat/jixin-card` to make `Card` source files clean against the strict Checkstyle + SpotBugs gates introduced in #25 (`feat/jixin-linters`).

Two violations fixed:
- **`Card.java`** — SpotBugs `CT_CONSTRUCTOR_THROW` (constructor throws an exception, vulnerable to finalizer attack on a subclass). Closed by marking the class `final`. `Card` is a simple immutable value type, so subclassing was never intended.
- **`CardTest.java`** — Checkstyle `CustomImportOrder` (`STATIC###THIRD_PARTY_PACKAGE`). Moved the two `import static org.junit.jupiter.api.Assertions.*` lines above the non-static imports.

## Verification
- Linter configs from `feat/jixin-linters` were temporarily copied into the workspace; `./gradlew build` passes (Checkstyle + SpotBugs + tests, strict mode).
- Linter configs are NOT included in this PR — they belong to #25. This PR contains only source-code refactors so the two PRs can merge independently in either order.
- After both PRs land on `main`, CI will exercise the linters on this code automatically.

## Test plan
- [x] `./gradlew build` passes locally with linter configs from #25 in place
- [x] `./gradlew test` still green (10 Card tests pass)
- [ ] CI on this PR (no linters yet on `main`, so just compile + tests)
- [ ] After #25 merges, confirm CI on `main` is green