### PR TITLE
feat(game-loop): full playable loop, new card types, second win condition

### DIFF
--- a/docs/bva/bva-ActionController.md
+++ b/docs/bva/bva-ActionController.md
@@ -4,8 +4,104 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 ---
 
+## Method 1: ```public void shuffleDeck(Deck deck)```
 
+### Step 1-3 Results
 
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The deck to shuffle | Same cards, possibly reordered |
+| Step 2 | `Deck` | void (deck mutated) |
+| Step 3 | a full deck | size unchanged, same multiset of cards |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `shuffleDeck(new Deck())` | deck size unchanged (63) | no |
+
+---
+
+## Method 2: ```public List<Card> peekTopThree(Deck deck)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The draw pile | Up to the top 3 cards, in draw order |
+| Step 2 | `Deck` | `List<Card>` |
+| Step 3 | deck of size 0, 2, >=3 | empty list / 2-card list / 3-card list; deck size unchanged |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `peekTopThree` on a full deck | list of size 3; deck size unchanged | no |
+| TC2 | `peekTopThree` on a 2-card deck | list of size 2 | no |
+| TC3 | `peekTopThree` on an empty deck | empty list | no |
+
+---
+
+## Method 3: ```public void reverseDirection(TurnTracker turnTracker)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The turn tracker | Playing direction flipped |
+| Step 2 | `TurnTracker` | void (tracker mutated) |
+| Step 3 | direction +1, direction -1 | becomes -1 / becomes +1 |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | tracker with direction +1 | `getCurrentDirection() == -1` | no |
+| TC2 | tracker with direction -1 | `getCurrentDirection() == 1` | no |
+
+---
+
+## Method 4: ```public void giveCard(Player from, Player to, int cardIndex)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | Giver, receiver, index of the card to give | Card moves from giver to receiver |
+| Step 2 | two `Player`, `int` | void (hands mutated) / `IndexOutOfBoundsException` |
+| Step 3 | valid index, out-of-range index | card transferred / exception |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `from` has one DEFUSE, `giveCard(from, to, 0)` | `from` hand size 0, `to` hand has the DEFUSE | no |
+| TC2 | `giveCard(from, to, 0)` when `from` hand empty | throws `IndexOutOfBoundsException` | no |
+
+---
+
+## Method 5: ```public void stealRandomCard(Player from, Player to)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | Victim and thief | One random card moves from victim to thief |
+| Step 2 | two `Player` (with injected `Random`) | void (hands mutated) |
+| Step 3 | victim with 0 cards, 1 card, many cards (seeded random) | no-op / that card moves / the seeded-index card moves |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | victim has exactly one card | that card moves to thief; victim hand size 0 | no |
+| TC2 | victim has several cards, seeded `Random` | the card at the seeded index moves to thief | no |
+| TC3 | victim has no cards | no-op; thief hand unchanged | no |
 
 ---
 

--- a/docs/bva/bva-ActionController.md
+++ b/docs/bva/bva-ActionController.md
@@ -19,7 +19,7 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `shuffleDeck(new Deck())` | deck size unchanged (63) | no |
+| TC1 | `shuffleDeck(new Deck())` | deck size unchanged (63) | yes |
 
 ---
 
@@ -38,9 +38,9 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `peekTopThree` on a full deck | list of size 3; deck size unchanged | no |
-| TC2 | `peekTopThree` on a 2-card deck | list of size 2 | no |
-| TC3 | `peekTopThree` on an empty deck | empty list | no |
+| TC1 | `peekTopThree` on a full deck | list of size 3; deck size unchanged | yes |
+| TC2 | `peekTopThree` on a 2-card deck | list of size 2 | yes |
+| TC3 | `peekTopThree` on an empty deck | empty list | yes |
 
 ---
 
@@ -59,8 +59,8 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | tracker with direction +1 | `getCurrentDirection() == -1` | no |
-| TC2 | tracker with direction -1 | `getCurrentDirection() == 1` | no |
+| TC1 | tracker with direction +1 | `getCurrentDirection() == -1` | yes |
+| TC2 | tracker with direction -1 | `getCurrentDirection() == 1` | yes |
 
 ---
 
@@ -79,8 +79,8 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `from` has one DEFUSE, `giveCard(from, to, 0)` | `from` hand size 0, `to` hand has the DEFUSE | no |
-| TC2 | `giveCard(from, to, 0)` when `from` hand empty | throws `IndexOutOfBoundsException` | no |
+| TC1 | `from` has one DEFUSE, `giveCard(from, to, 0)` | `from` hand size 0, `to` hand has the DEFUSE | yes |
+| TC2 | `giveCard(from, to, 0)` when `from` hand empty | throws `IndexOutOfBoundsException` | yes |
 
 ---
 
@@ -99,9 +99,9 @@ This file holds the BVA analysis for every public method of the `ActionControlle
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | victim has exactly one card | that card moves to thief; victim hand size 0 | no |
-| TC2 | victim has several cards, seeded `Random` | the card at the seeded index moves to thief | no |
-| TC3 | victim has no cards | no-op; thief hand unchanged | no |
+| TC1 | victim has exactly one card | that card moves to thief; victim hand size 0 | yes |
+| TC2 | victim has several cards, seeded `Random` | the card at the seeded index moves to thief | yes |
+| TC3 | victim has no cards | no-op; thief hand unchanged | yes |
 
 ---
 

--- a/docs/bva/bva-Card.md
+++ b/docs/bva/bva-Card.md
@@ -24,7 +24,7 @@
 |--------|-----------------------------|---------------------------------|---------------------------------------------------------------------------------------|
 | Step 1 | none (instance-state query) |                                 | The `CardType` value supplied at construction                                         |
 | Step 2 | n/a                         |                                 | Enumeration (`CardType`)                                                              |
-| Step 3 | n/a                         |                                 | `EXPLODING_KITTEN`, `DEFUSE`, `ATTACK`, `SHUFFLE`, `SKIP`, `SEE_THE_FUTURE`, `NOPE`, `CAT_CARDS`, `FAVOR` |
+| Step 3 | n/a                         |                                 | `EXPLODING_KITTEN`, `DEFUSE`, `ATTACK`, `SHUFFLE`, `SKIP`, `SEE_THE_FUTURE`, `NOPE`, `CAT_CARDS`, `FAVOR`, `REVERSE`, `TARGETED_ATTACK` |
 
 ### Step 4:
 ##### All-combination or each-choice: each-choice
@@ -40,6 +40,8 @@
 | Test Case 7  | `new Card(NOPE)`             | `NOPE`             | yes          |
 | Test Case 8  | `new Card(CAT_CARDS)`        | `CAT_CARDS`        | yes          |
 | Test Case 9  | `new Card(FAVOR)`            | `FAVOR`            | yes          |
+| Test Case 10 | `new Card(REVERSE)`          | `REVERSE`          | yes          |
+| Test Case 11 | `new Card(TARGETED_ATTACK)`  | `TARGETED_ATTACK`  | yes          |
 
 ---
 

--- a/docs/bva/bva-Deck.md
+++ b/docs/bva/bva-Deck.md
@@ -8,14 +8,14 @@
 |------|-----------------------------------|-----------------------|
 | Step 1 | No input parameters (constructor) | Fully initialized deck |
 | Step 2 | N/A                               | `List<Card>`            |
-| Step 3 | N/A                               | 56 cards in the deck  |
+| Step 3 | N/A                               | 63 cards in the deck  |
 
 ### Step 4:
 ##### each-choice
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|-------------|
-| TC1 | `new Deck()` | deck size = 56 | yes         |
+| TC1 | `new Deck()` | deck size = 63 | yes         |
 | TC2 | `new Deck()` | first card = EXPLODING_KITTEN | yes         |
 | TC3 | `new Deck()` | last card = CAT_CARDS | yes         |
 | TC4 | `new Deck()` | correct full ordering of cards | yes         |
@@ -28,9 +28,9 @@
 
 | Step | Input                      | Output                                     |
 |------|----------------------------|--------------------------------------------|
-| Step 1 | Deck state (0,1,2,56 cards) | Modified deck                              |
+| Step 1 | Deck state (0,1,2,63 cards) | Modified deck                              |
 | Step 2 | deck `List<Card>`           | Card Object                                |
-| Step 3 | deck sizes: 0, 1, 2, 56    | return top Card and deck size decrease by 1 |
+| Step 3 | deck sizes: 0, 1, 2, 63    | return top Card and deck size decrease by 1 |
 
 ### Step 4:
 ##### each-choice
@@ -40,7 +40,7 @@
 | TC1 | empty drawPile (`[]`) | throws IllegalStateException with message "deck.emptyType" | yes         |
 | TC2 | drawPile size = 1 | returns Card, drawPile becomes `[]` | yes         |
 | TC3 | drawPile size = 2 | returns Card, drawPile size becomes `1` | yes         |
-| TC4 | drawPile size = 56 | returns Card, drawPile size becomes `55` | yes         |
+| TC4 | drawPile size = 63 | returns Card, drawPile size becomes `62` | yes         |
 
 ---
 
@@ -52,7 +52,7 @@
 |------|----------------------------|--------------------------|
 | Step 1 | The current drawPile state. | Reordered deck state with same elements  |
 | Step 2 | deck `List<Card>`           | N/A                      |
-| Step 3 | deck sizes: 0,1,2,56       | same elements, same size |
+| Step 3 | deck sizes: 0,1,2,63       | same elements, same size |
 
 ### Step 4:
 ##### each-choice
@@ -62,7 +62,7 @@
 | TC1 | empty deck (`[]`) | empty deck unchanged | yes          |
 | TC2 | deck size = 1 | same single card | yes          |
 | TC3 | deck size = 2 | same elements, order may change | yes          |
-| TC4 | deck size = 56 | same elements, order may change | yes          |
+| TC4 | deck size = 63 | same elements, order may change | yes          |
 
 ---
 
@@ -74,7 +74,7 @@
 |------|------------------------------------------------------------|---------------------------------------------------------------|
 | Step 1 | The current drawPile state and number of requested cards n | a list containing the top n cards from the deck               |
 | Step 2 | deck `List<Card>` and Integer n                            | List<Card> / IllegalStateException / IllegalArgumentException |
-| Step 3 | deck sizes: 0,1,2,56, int n: -1, 0, 1, 3, 55, 56, 57       | List<Card> / IllegalStateException / IllegalArgumentException |
+| Step 3 | deck sizes: 0,1,2,63, int n: -1, 0, 1, 3, 55, 63, 64       | List<Card> / IllegalStateException / IllegalArgumentException |
 
 ### Step 4:
 ##### each-choice
@@ -84,10 +84,10 @@
 | TC1         | deck size = 0, int n = -1  | throws IllegalArgumentException with message "deck.peekTop.negativeN" | yes         |
 | TC2         | deck size = 1, int n = 0   | an empty list (`[]`) and deck size = 1                                         | yes         |
 | TC3         | deck size = 2, int n = 1   | new list containing the first card with size = 1 and deck size = 2             | yes         |
-| TC4         | deck size = 56, int n = 3  | new list containing the first 3 elements with size = 3 and deck size = 56      | yes         |
-| TC5         | deck size = 56, int n = 55 | new list containing the first 55 elements with size = 55 and deck size = 56    | yes         |
-| TC6         | deck size = 56, int n = 56 | new list containing all the elements with size = 56 and deck size = 56         | yes         |
-| TC7         | deck size = 56, int n = 57 | throws IllegalStateException with message "deck.peekTop.tooManyRequested" | yes         |
+| TC4         | deck size = 63, int n = 3  | new list containing the first 3 elements with size = 3 and deck size = 63      | yes         |
+| TC5         | deck size = 63, int n = 55 | new list containing the first 55 elements with size = 55 and deck size = 63    | yes         |
+| TC6         | deck size = 63, int n = 63 | new list containing all the elements with size = 63 and deck size = 63         | yes         |
+| TC7         | deck size = 63, int n = 64 | throws IllegalStateException with message "deck.peekTop.tooManyRequested" | yes         |
 | TC8         | deck size = 3, int n = 5   | throws IllegalStateException with message "deck.peekTop.tooManyRequested" | yes         |
 
 ---
@@ -123,8 +123,8 @@
 - input: void
 - output: int
 - TC 6.1: getSize_InitialDeck_ReturnsDeckSize
-    - State of the system: Deck with list of 56 cards
-    - Expected output: returns 56
+    - State of the system: Deck with list of 63 cards
+    - Expected output: returns 63
     - Implemented: yes
 - TC 6.2: getSize_EmptyDeck_ReturnsZero
   - State of the system: Deck with list of 0 cards
@@ -136,7 +136,7 @@
 - input: void
 - output: boolean
 - TC 7.1: isEmpty_InitialDeck_ReturnsFalse
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: returns false
   - Implemented: yes
 - TC 7.2: isEmpty_EmptyDeck_ReturnsTrue
@@ -150,37 +150,37 @@
 - output: boolean
 - TC 8.1: insertAt_InitialDeck_ReturnsTrue
   - input: Card EXPLODING_KITTEN, int 0
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: returns true
   - Implemented: yes
 - TC 8.2: insertAt_InitialDeckIndex1_ReturnsTrue
   - input: Card EXPLODING_KITTEN, int 1
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: returns true
   - Implemented: yes
-- TC 8.3: insertAt_InitialDeckIndex56_ReturnsTrue
-  - input: Card EXPLODING_KITTEN, int 56
-  - State of the system: Deck with list of 56 cards
+- TC 8.3: insertAt_InitialDeckIndex63_ReturnsTrue
+  - input: Card EXPLODING_KITTEN, int 63
+  - State of the system: Deck with list of 63 cards
   - Expected output: returns true
   - Implemented: yes
-- TC 8.4: insertAt_InitialDeckIndex57_ThrowsException
-  - input: Card EXPLODING_KITTEN, int 57
-  - State of the system: Deck with list of 56 cards
+- TC 8.4: insertAt_InitialDeckIndex64_ThrowsException
+  - input: Card EXPLODING_KITTEN, int 64
+  - State of the system: Deck with list of 63 cards
   - Expected output: throws IllegalArgumentException error
   - Implemented: yes
 - TC 8.5: insertAt_InitialDeckIndexNeg1_ThrowsException
   - input: Card EXPLODING_KITTEN, int -1
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: throws IllegalArgumentException error
   - Implemented: yes
 - TC 8.6: insertAt_InitialDeckNullCard_ThrowsException
   - input: Card null, int 1
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: throws IllegalArgumentException error
   - Implemented: yes
 - TC 8.7: insertAt_InitialDeckNullCardNeg1_ThrowsException
   - input: Card null, int -1
-  - State of the system: Deck with list of 56 cards
+  - State of the system: Deck with list of 63 cards
   - Expected output: throws IllegalArgumentException error
   - Implemented: yes
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -210,8 +210,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current player given a SKIP, `playSkip()` (2 players) | turn passes to player 1; draw pile unchanged | no |
-| TC2 | current player has no SKIP, `playSkip()` | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | no |
+| TC1 | current player given a SKIP, `playSkip()` (2 players) | turn passes to player 1; draw pile unchanged | yes |
+| TC2 | current player has no SKIP, `playSkip()` | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | yes |
 
 ---
 
@@ -230,7 +230,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current player given a SHUFFLE, `playShuffle()` | `getCurrentPlayerId()` unchanged; draw pile size unchanged | no |
+| TC1 | current player given a SHUFFLE, `playShuffle()` | `getCurrentPlayerId()` unchanged; draw pile size unchanged | yes |
 
 ---
 
@@ -249,7 +249,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current player given a SEE_THE_FUTURE, `playSeeTheFuture()` | returns list of size 3; `getCurrentPlayerId()` unchanged | no |
+| TC1 | current player given a SEE_THE_FUTURE, `playSeeTheFuture()` | returns list of size 3; `getCurrentPlayerId()` unchanged | yes |
 
 ---
 
@@ -268,7 +268,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current player given a REVERSE, `playReverse()` (2 players) | turn passes to player 1 | no |
+| TC1 | current player given a REVERSE, `playReverse()` (2 players) | turn passes to player 1 | yes |
 
 ---
 
@@ -287,8 +287,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current player given an ATTACK, `playAttack()` (2 players, normal turn) | `getCurrentPlayerId()==1`, `getForcedTurns()==2` | no |
-| TC2 | player 1 (owing 2 after an attack) given an ATTACK, `playAttack()` | turn passes, the next player owes 4 | no |
+| TC1 | current player given an ATTACK, `playAttack()` (2 players, normal turn) | `getCurrentPlayerId()==1`, `getForcedTurns()==2` | yes |
+| TC2 | player 1 (owing 2 after an attack) given an ATTACK, `playAttack()` | turn passes, the next player owes 4 | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -408,9 +408,9 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `new GameEngine(2)` at game start | `false` | no |
-| TC2 | one player marked dead | `true` | no |
-| TC3 | draw pile drained to empty, both alive | `true` | no |
+| TC1 | `new GameEngine(2)` at game start | `false` | yes |
+| TC2 | one player marked dead | `true` | yes |
+| TC3 | draw pile drained to empty, both alive | `true` | yes |
 
 ---
 
@@ -429,10 +429,10 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `getWinnerId()` before the game is over | throws `IllegalStateException` with message `"gameEngine.notOver"` | no |
-| TC2 | player 0 marked dead (2 players) | `1` (last player standing) | no |
-| TC3 | draw pile drained by player 0 (most cards), both alive | `0` | no |
-| TC4 | exhausted pile with both hands equal | `0` (tie broken by lowest id) | no |
+| TC1 | `getWinnerId()` before the game is over | throws `IllegalStateException` with message `"gameEngine.notOver"` | yes |
+| TC2 | player 0 marked dead (2 players) | `1` (last player standing) | yes |
+| TC3 | draw pile drained by player 0 (most cards), both alive | `0` | yes |
+| TC4 | exhausted pile with both hands equal | `0` (tie broken by lowest id) | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -436,6 +436,27 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 ---
 
+## Method 22: ```public void playNope(int noperId)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | a played card to cancel; the noper who holds a NOPE | NOPE discarded; `lastPlayedCard` cleared |
+| Step 2 | `int` noper id | void / `IllegalStateException` |
+| Step 3 | something to nope + noper holds NOPE, nothing played yet, noper holds no NOPE | cancels / `rule.nope.nothingToCancel` / `gameEngine.play.notInHand` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | a card was just played, noper holds a NOPE, `playNope(noperId)` | `getLastPlayedCard()` becomes `null` | no |
+| TC2 | nothing played yet, `playNope(0)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | no |
+| TC3 | a card was just played, noper holds no NOPE | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | no |
+
+---
+
 ## Recall the 4 steps of BVA
 ### Step 1: Describe the input and output in terms of the domain.
 ### Step 2: Choose the data type for the input and the output from the BVA Catalog.

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -451,9 +451,9 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | a card was just played, noper holds a NOPE, `playNope(noperId)` | `getLastPlayedCard()` becomes `null` | no |
-| TC2 | nothing played yet, `playNope(0)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | no |
-| TC3 | a card was just played, noper holds no NOPE | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | no |
+| TC1 | a card was just played, noper holds a NOPE, `playNope(noperId)` | `getLastPlayedCard()` becomes `null` | yes |
+| TC2 | nothing played yet, `playNope(0)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | yes |
+| TC3 | a card was just played, noper holds no NOPE | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -393,6 +393,49 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 ---
 
+## Method 20: ```public boolean isGameOver()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current alive count and draw pile | whether the game has ended |
+| Step 2 | game state | `boolean` |
+| Step 3 | 2 alive + non-empty pile, 1 alive, 2 alive + empty pile | `false` / `true` / `true` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `new GameEngine(2)` at game start | `false` | no |
+| TC2 | one player marked dead | `true` | no |
+| TC3 | draw pile drained to empty, both alive | `true` | no |
+
+---
+
+## Method 21: ```public int getWinnerId()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | the finished game state | id of the winner |
+| Step 2 | game state | `int` / `IllegalStateException` |
+| Step 3 | not over, last player standing, exhausted pile with a clear leader, exhausted pile tie | exception / survivor id / most-cards id / lowest id |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `getWinnerId()` before the game is over | throws `IllegalStateException` with message `"gameEngine.notOver"` | no |
+| TC2 | player 0 marked dead (2 players) | `1` (last player standing) | no |
+| TC3 | draw pile drained by player 0 (most cards), both alive | `0` | no |
+| TC4 | exhausted pile with both hands equal | `0` (tie broken by lowest id) | no |
+
+---
+
 ## Recall the 4 steps of BVA
 ### Step 1: Describe the input and output in terms of the domain.
 ### Step 2: Choose the data type for the input and the output from the BVA Catalog.

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -307,8 +307,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | 3 players, current 0 given TARGETED_ATTACK, `playTargetedAttack(2)` | `getCurrentPlayerId()==2`, `getForcedTurns()==2` | no |
-| TC2 | `playTargetedAttack(0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+| TC1 | 3 players, current 0 given TARGETED_ATTACK, `playTargetedAttack(2)` | `getCurrentPlayerId()==2`, `getForcedTurns()==2` | yes |
+| TC2 | `playTargetedAttack(0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | yes |
 
 ---
 
@@ -327,8 +327,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | 2 players, current 0 given FAVOR, `playFavor(1, 0)` | target hand shrinks by 1; current keeps the turn | no |
-| TC2 | `playFavor(0, 0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+| TC1 | 2 players, current 0 given FAVOR, `playFavor(1, 0)` | target hand shrinks by 1; current keeps the turn | yes |
+| TC2 | `playFavor(0, 0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | yes |
 
 ---
 
@@ -347,8 +347,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | 2 players, current 0 given 2 CAT_CARDS, `playCatPair(1)` | target hand shrinks by 1, current keeps the turn | no |
-| TC2 | current holds no extra cats, `playCatPair(1)` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
+| TC1 | 2 players, current 0 given 2 CAT_CARDS, `playCatPair(1)` | target hand shrinks by 1, current keeps the turn | yes |
+| TC2 | current holds no extra cats, `playCatPair(1)` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | yes |
 
 ---
 
@@ -367,9 +367,9 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | current given an Exploding Kitten, `defuseDrawnKitten(0)` | current still alive, kitten gone from hand, draw pile grows by 1, turn passes | no |
-| TC2 | current has no Exploding Kitten, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | no |
-| TC3 | current given a kitten but no Defuse, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noDefuse"` | no |
+| TC1 | current given an Exploding Kitten, `defuseDrawnKitten(0)` | current still alive, kitten gone from hand, draw pile grows by 1, turn passes | yes |
+| TC2 | current has no Exploding Kitten, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | yes |
+| TC3 | current given a kitten but no Defuse, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noDefuse"` | yes |
 
 ---
 
@@ -388,8 +388,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | 2 players, current given an Exploding Kitten, `explodeCurrentPlayer()` | `getPlayer(0).isAlive()==false`, `getCurrentPlayerId()==1` | no |
-| TC2 | current has no Exploding Kitten, `explodeCurrentPlayer()` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | no |
+| TC1 | 2 players, current given an Exploding Kitten, `explodeCurrentPlayer()` | `getPlayer(0).isAlive()==false`, `getCurrentPlayerId()==1` | yes |
+| TC2 | current has no Exploding Kitten, `explodeCurrentPlayer()` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -391,6 +391,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 |-------------|------------------|-----------------|--------------|
 | TC1 | 2 players, current given an Exploding Kitten, `explodeCurrentPlayer()` | `getPlayer(0).isAlive()==false`, `getCurrentPlayerId()==1` | yes |
 | TC2 | current has no Exploding Kitten, `explodeCurrentPlayer()` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | yes |
+| TC3 | current with extra cards explodes | eliminated player's hand is emptied (cards discarded) | no |
 
 ---
 
@@ -455,6 +456,48 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 | TC1 | a card was just played, noper holds a NOPE, `playNope(noperId)` | `getLastPlayedCard()` becomes `null` | yes |
 | TC2 | nothing played yet, `playNope(0)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | yes |
 | TC3 | a card was just played, noper holds no NOPE | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | yes |
+
+---
+
+## Method 23: ```public void endTurnByDrawing()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | the current player has just taken a safe draw | one owed turn consumed; turn passes to the next living player only when none remain |
+| Step 2 | game state (`forcedTurns`, alive flags) | state mutation on the turn tracker |
+| Step 3 | normal turn (owe 1), stacked turn (owe 2), next seat dead | advance to next living / same player keeps the turn / dead seat skipped |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | 2 players, normal turn, `endTurnByDrawing()` | `getCurrentPlayerId()==1`, `getForcedTurns()==1` | no |
+| TC2 | player owing 2 (after an Attack), `endTurnByDrawing()` | same player keeps the turn; `getForcedTurns()==1` | no |
+| TC3 | 3 players, next seat eliminated, `endTurnByDrawing()` | turn skips the dead seat to the next living player | no |
+
+---
+
+## Method 24: ```public List<Card> getDiscardPile()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | none (instance query) | A defensive copy of the discard pile |
+| Step 2 | n/a | `List<Card>` |
+| Step 3 | nothing discarded, one card discarded | empty list / list of size 1; mutating the copy does not affect the game |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `getDiscardPile()` at game start | empty list | no |
+| TC2 | after `playSkip()`, `getDiscardPile()` | list of size 1 containing the SKIP | no |
+| TC3 | mutate the returned list, then `getDiscardPile()` again | discard pile unchanged (defensive copy) | no |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -292,6 +292,107 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 ---
 
+## Method 15: ```public void playTargetedAttack(int targetId)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current holds TARGETED_ATTACK; a chosen living opponent | turn jumps to the target who owes 2 turns |
+| Step 2 | `int` target id | void / `IllegalArgumentException` for bad target |
+| Step 3 | distinct living target, self/dead target | turn to target, owes 2 / `rule.target.invalid` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | 3 players, current 0 given TARGETED_ATTACK, `playTargetedAttack(2)` | `getCurrentPlayerId()==2`, `getForcedTurns()==2` | no |
+| TC2 | `playTargetedAttack(0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+
+---
+
+## Method 16: ```public void playFavor(int targetId, int cardIndex)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current holds FAVOR; target and the index of the card to take | that card moves from target to current; same player continues |
+| Step 2 | two `int` | void / exception for bad target or index |
+| Step 3 | valid target + index, self target | card transferred / `rule.target.invalid` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | 2 players, current 0 given FAVOR, `playFavor(1, 0)` | target hand shrinks by 1; current keeps the turn | no |
+| TC2 | `playFavor(0, 0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+
+---
+
+## Method 17: ```public void playCatPair(int targetId)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current holds 2 CAT_CARDS; a target | one random card moves from target to current; same player continues |
+| Step 2 | `int` target id | void / exception for bad target or too few cats |
+| Step 3 | 2 cats + valid target, fewer than 2 cats | steal happens / `rule.catPair.needTwo` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | 2 players, current 0 given 2 CAT_CARDS, `playCatPair(1)` | target hand shrinks by 1, current keeps the turn | no |
+| TC2 | current holds no extra cats, `playCatPair(1)` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
+
+---
+
+## Method 18: ```public void defuseDrawnKitten(int reinsertIndex)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current holds a drawn Exploding Kitten and a Defuse; reinsert index | kitten reinserted, Defuse discarded, turn ends; player survives |
+| Step 2 | `int` index | void / `IllegalStateException` |
+| Step 3 | has kitten + defuse, no kitten, no defuse | survives / `gameEngine.defuse.noKitten` / `gameEngine.defuse.noDefuse` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current given an Exploding Kitten, `defuseDrawnKitten(0)` | current still alive, kitten gone from hand, draw pile grows by 1, turn passes | no |
+| TC2 | current has no Exploding Kitten, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | no |
+| TC3 | current given a kitten but no Defuse, `defuseDrawnKitten(0)` | throws `IllegalStateException` with message `"gameEngine.defuse.noDefuse"` | no |
+
+---
+
+## Method 19: ```public void explodeCurrentPlayer()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current holds a drawn Exploding Kitten | current dies; turn passes to the next living player |
+| Step 2 | none | void / `IllegalStateException` |
+| Step 3 | has kitten, no kitten | dies + turn passes / `gameEngine.defuse.noKitten` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | 2 players, current given an Exploding Kitten, `explodeCurrentPlayer()` | `getPlayer(0).isAlive()==false`, `getCurrentPlayerId()==1` | no |
+| TC2 | current has no Exploding Kitten, `explodeCurrentPlayer()` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | no |
+
+---
+
 ## Recall the 4 steps of BVA
 ### Step 1: Describe the input and output in terms of the domain.
 ### Step 2: Choose the data type for the input and the output from the BVA Catalog.

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -195,6 +195,103 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 ---
 
+## Method 10: ```public void playSkip()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current player holds a SKIP | SKIP discarded; one owed turn ended without drawing |
+| Step 2 | game state | void / `IllegalStateException` if no SKIP held |
+| Step 3 | holds SKIP (normal turn), holds no SKIP | turn passes to next / `gameEngine.play.notInHand` |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current player given a SKIP, `playSkip()` (2 players) | turn passes to player 1; draw pile unchanged | no |
+| TC2 | current player has no SKIP, `playSkip()` | throws `IllegalStateException` with message `"gameEngine.play.notInHand"` | no |
+
+---
+
+## Method 11: ```public void playShuffle()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current player holds a SHUFFLE | SHUFFLE discarded; draw pile reordered; same player continues |
+| Step 2 | game state | void |
+| Step 3 | holds SHUFFLE | draw pile size unchanged, current player unchanged |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current player given a SHUFFLE, `playShuffle()` | `getCurrentPlayerId()` unchanged; draw pile size unchanged | no |
+
+---
+
+## Method 12: ```public List<Card> playSeeTheFuture()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current player holds a SEE_THE_FUTURE | up to top 3 cards returned; same player continues |
+| Step 2 | game state | `List<Card>` |
+| Step 3 | holds SEE_THE_FUTURE, full draw pile | list of size 3 |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current player given a SEE_THE_FUTURE, `playSeeTheFuture()` | returns list of size 3; `getCurrentPlayerId()` unchanged | no |
+
+---
+
+## Method 13: ```public void playReverse()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current player holds a REVERSE | REVERSE discarded; direction flipped; one owed turn ended |
+| Step 2 | game state | void |
+| Step 3 | holds REVERSE (2 players, forward) | direction becomes -1; turn passes |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current player given a REVERSE, `playReverse()` (2 players) | turn passes to player 1 | no |
+
+---
+
+## Method 14: ```public void playAttack()```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | current player holds an ATTACK | ATTACK discarded; turn ends without drawing; next player owes 2 turns |
+| Step 2 | game state | void |
+| Step 3 | normal turn (owe 1), stacked turn (owe 2) | next owes 2 / next owes 4 |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | current player given an ATTACK, `playAttack()` (2 players, normal turn) | `getCurrentPlayerId()==1`, `getForcedTurns()==2` | no |
+| TC2 | player 1 (owing 2 after an attack) given an ATTACK, `playAttack()` | turn passes, the next player owes 4 | no |
+
+---
+
 ## Recall the 4 steps of BVA
 ### Step 1: Describe the input and output in terms of the domain.
 ### Step 2: Choose the data type for the input and the output from the BVA Catalog.

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -391,7 +391,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 |-------------|------------------|-----------------|--------------|
 | TC1 | 2 players, current given an Exploding Kitten, `explodeCurrentPlayer()` | `getPlayer(0).isAlive()==false`, `getCurrentPlayerId()==1` | yes |
 | TC2 | current has no Exploding Kitten, `explodeCurrentPlayer()` | throws `IllegalStateException` with message `"gameEngine.defuse.noKitten"` | yes |
-| TC3 | current with extra cards explodes | eliminated player's hand is emptied (cards discarded) | no |
+| TC3 | current with extra cards explodes | eliminated player's hand is emptied (cards discarded) | yes |
 
 ---
 
@@ -474,9 +474,9 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | 2 players, normal turn, `endTurnByDrawing()` | `getCurrentPlayerId()==1`, `getForcedTurns()==1` | no |
-| TC2 | player owing 2 (after an Attack), `endTurnByDrawing()` | same player keeps the turn; `getForcedTurns()==1` | no |
-| TC3 | 3 players, next seat eliminated, `endTurnByDrawing()` | turn skips the dead seat to the next living player | no |
+| TC1 | 2 players, normal turn, `endTurnByDrawing()` | `getCurrentPlayerId()==1`, `getForcedTurns()==1` | yes |
+| TC2 | player owing 2 (after an Attack), `endTurnByDrawing()` | same player keeps the turn; `getForcedTurns()==1` | yes |
+| TC3 | 3 players, next seat eliminated, `endTurnByDrawing()` | turn skips the dead seat to the next living player | yes |
 
 ---
 
@@ -495,9 +495,9 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `getDiscardPile()` at game start | empty list | no |
-| TC2 | after `playSkip()`, `getDiscardPile()` | list of size 1 containing the SKIP | no |
-| TC3 | mutate the returned list, then `getDiscardPile()` again | discard pile unchanged (defensive copy) | no |
+| TC1 | `getDiscardPile()` at game start | empty list | yes |
+| TC2 | after `playSkip()`, `getDiscardPile()` | list of size 1 containing the SKIP | yes |
+| TC3 | mutate the returned list, then `getDiscardPile()` again | discard pile unchanged (defensive copy) | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -26,8 +26,8 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 | TC5 | `new GameEngine(0)` | throws `IllegalArgumentException` with message `"gameEngine.numPlayers.outOfRange"` | yes |
 | TC6 | `new GameEngine(-1)` | throws `IllegalArgumentException` with message `"gameEngine.numPlayers.outOfRange"` | yes |
 | TC7 | `new GameEngine(2)` post-state | each player has 5 cards in hand (1 Defuse + 4 others, no Exploding Kitten) | yes |
-| TC8 | `new GameEngine(2)` post-state | draw pile size is `43` (38 non-EK non-Defuse + (6-n) Defuses + (n-1) EK = 38 + 4 + 1) | yes |
-| TC9 | `new GameEngine(5)` post-state | draw pile size is `31` (26 + 1 + 4) | yes |
+| TC8 | `new GameEngine(2)` post-state | draw pile size is `50` (45 non-EK non-Defuse + (6-n) Defuses + (n-1) EK = 45 + 4 + 1) | yes |
+| TC9 | `new GameEngine(5)` post-state | draw pile size is `38` (33 + 1 + 4) | yes |
 
 ---
 
@@ -101,15 +101,15 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 |------|-------|--------|
 | Step 1 | none (instance query) | Number of cards still in the draw pile |
 | Step 2 | n/a | `int` |
-| Step 3 | game start at `n=2`, `n=5` | `43`, `31` |
+| Step 3 | game start at `n=2`, `n=5` | `50`, `38` |
 
 ### Step 4:
 ##### All-combination or each-choice: each-choice
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `new GameEngine(2).getDrawPileSize()` | `43` | yes |
-| TC2 | `new GameEngine(5).getDrawPileSize()` | `31` | yes |
+| TC1 | `new GameEngine(2).getDrawPileSize()` | `50` | yes |
+| TC2 | `new GameEngine(5).getDrawPileSize()` | `38` | yes |
 
 ---
 

--- a/docs/bva/bva-GameEngine.md
+++ b/docs/bva/bva-GameEngine.md
@@ -329,6 +329,7 @@ This file holds the BVA analysis for every public method of the `GameEngine` cla
 |-------------|------------------|-----------------|--------------|
 | TC1 | 2 players, current 0 given FAVOR, `playFavor(1, 0)` | target hand shrinks by 1; current keeps the turn | yes |
 | TC2 | `playFavor(0, 0)` by player 0 (self) | throws `IllegalArgumentException` with message `"rule.target.invalid"` | yes |
+| TC3 | `playFavor(1, size)` with a card index past the target's hand | throws `IndexOutOfBoundsException` with message `"player.removeCardFromHand.invalidIndex"` | yes |
 
 ---
 

--- a/docs/bva/bva-RuleManager.md
+++ b/docs/bva/bva-RuleManager.md
@@ -4,8 +4,86 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 
 ---
 
+## Method 1: ```public void requirePlayable(CardType type)```
 
+### Step 1-3 Results
 
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The card type a player wants to play | nothing (legal) or exception (illegal) |
+| Step 2 | Enum (`CardType`) | void / `IllegalArgumentException` |
+| Step 3 | `DEFUSE`, `EXPLODING_KITTEN` (illegal), any other type e.g. `SKIP` (legal) | exception / exception / returns normally |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `requirePlayable(SKIP)` | returns normally | no |
+| TC2 | `requirePlayable(DEFUSE)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | no |
+| TC3 | `requirePlayable(EXPLODING_KITTEN)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | no |
+
+---
+
+## Method 2: ```public void requireValidTarget(Player actor, Player target)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The acting player and the chosen target | nothing (legal) or exception (illegal) |
+| Step 2 | two `Player` references | void / `IllegalArgumentException` |
+| Step 3 | distinct living target (legal), target == actor (illegal), dead target (illegal) | returns normally / exception / exception |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | actor id 0, distinct living target id 1 | returns normally | no |
+| TC2 | actor and target are the same player | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+| TC3 | distinct target that is not alive | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+
+---
+
+## Method 3: ```public void requireCatPair(Player actor)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The acting player's hand | nothing (legal) or exception (illegal) |
+| Step 2 | `Player` reference | void / `IllegalStateException` |
+| Step 3 | 0, 1 cat cards (illegal), 2, 3 cat cards (legal) | exception / exception / returns normally / returns normally |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | actor holds 2 `CAT_CARDS` | returns normally | no |
+| TC2 | actor holds 0 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
+| TC3 | actor holds 1 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
+
+---
+
+## Method 4: ```public void requireSomethingToNope(CardType lastPlayedCard)```
+
+### Step 1-3 Results
+
+| Step | Input | Output |
+|------|-------|--------|
+| Step 1 | The most recently played card type, or `null` if none | nothing (legal) or exception (illegal) |
+| Step 2 | `CardType` or `null` | void / `IllegalStateException` |
+| Step 3 | non-null last card (legal), `null` (illegal) | returns normally / exception |
+
+### Step 4:
+##### All-combination or each-choice: each-choice
+
+| Test Case # | System under test | Expected output | Implemented? |
+|-------------|------------------|-----------------|--------------|
+| TC1 | `requireSomethingToNope(ATTACK)` | returns normally | no |
+| TC2 | `requireSomethingToNope(null)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | no |
 
 ---
 

--- a/docs/bva/bva-RuleManager.md
+++ b/docs/bva/bva-RuleManager.md
@@ -19,9 +19,9 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `requirePlayable(SKIP)` | returns normally | no |
-| TC2 | `requirePlayable(DEFUSE)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | no |
-| TC3 | `requirePlayable(EXPLODING_KITTEN)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | no |
+| TC1 | `requirePlayable(SKIP)` | returns normally | yes |
+| TC2 | `requirePlayable(DEFUSE)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | yes |
+| TC3 | `requirePlayable(EXPLODING_KITTEN)` | throws `IllegalArgumentException` with message `"rule.play.cannotPlayDirectly"` | yes |
 
 ---
 
@@ -40,9 +40,9 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | actor id 0, distinct living target id 1 | returns normally | no |
-| TC2 | actor and target are the same player | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
-| TC3 | distinct target that is not alive | throws `IllegalArgumentException` with message `"rule.target.invalid"` | no |
+| TC1 | actor id 0, distinct living target id 1 | returns normally | yes |
+| TC2 | actor and target are the same player | throws `IllegalArgumentException` with message `"rule.target.invalid"` | yes |
+| TC3 | distinct target that is not alive | throws `IllegalArgumentException` with message `"rule.target.invalid"` | yes |
 
 ---
 
@@ -61,9 +61,10 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | actor holds 2 `CAT_CARDS` | returns normally | no |
-| TC2 | actor holds 0 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
-| TC3 | actor holds 1 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | no |
+| TC1 | actor holds 2 `CAT_CARDS` | returns normally | yes |
+| TC2 | actor holds 0 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | yes |
+| TC3 | actor holds 1 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | yes |
+| TC4 | actor holds 3 `CAT_CARDS` | returns normally | no |
 
 ---
 
@@ -82,8 +83,8 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 
 | Test Case # | System under test | Expected output | Implemented? |
 |-------------|------------------|-----------------|--------------|
-| TC1 | `requireSomethingToNope(ATTACK)` | returns normally | no |
-| TC2 | `requireSomethingToNope(null)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | no |
+| TC1 | `requireSomethingToNope(ATTACK)` | returns normally | yes |
+| TC2 | `requireSomethingToNope(null)` | throws `IllegalStateException` with message `"rule.nope.nothingToCancel"` | yes |
 
 ---
 

--- a/docs/bva/bva-RuleManager.md
+++ b/docs/bva/bva-RuleManager.md
@@ -64,7 +64,7 @@ This file holds the BVA analysis for every public method of the `RuleManager` cl
 | TC1 | actor holds 2 `CAT_CARDS` | returns normally | yes |
 | TC2 | actor holds 0 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | yes |
 | TC3 | actor holds 1 `CAT_CARDS` | throws `IllegalStateException` with message `"rule.catPair.needTwo"` | yes |
-| TC4 | actor holds 3 `CAT_CARDS` | returns normally | no |
+| TC4 | actor holds 3 `CAT_CARDS` | returns normally | yes |
 
 ---
 

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -103,8 +103,14 @@
 - `drawCardForCurrentPlayer(): Card` — draws the top card of the draw pile,
   adds it to the current player's hand, and returns it. Throws
   `IllegalStateException` (`deck.emptyType`) if the draw pile is empty.
-- `advanceToNextPlayer()` — hands the turn to the next player via
-  `TurnTracker.turnGoesToNextPlayer()`.
+- `advanceToNextPlayer()` — hands the turn to the next living player (skips
+  eliminated seats).
+- `endTurnByDrawing()` — ends the current turn after a safe (non-kitten) draw:
+  consumes one owed turn and, when none remain, advances to the next living
+  player. The UI calls this after `drawCardForCurrentPlayer()` returns a
+  non-kitten card, so Attack / Targeted Attack stacking is honoured.
+- `getDiscardPile(): List<Card>` — defensive copy of the discard pile for the
+  UI to render.
 - `getForcedTurns(): int` — draws the current player still owes before the turn
   passes (1 normally; raised by Attack / Targeted Attack).
 - `getLastPlayedCard(): CardType` — the most recently played card type (what a
@@ -130,7 +136,8 @@
 - `defuseDrawnKitten(int reinsertIndex)` — after drawing an Exploding Kitten,
   discards a DEFUSE, reinserts the kitten at `reinsertIndex`, and ends the turn.
 - `explodeCurrentPlayer()` — after drawing an Exploding Kitten with no Defuse,
-  marks the current player dead and ends the turn.
+  marks the current player dead, discards their remaining hand, and ends the
+  turn (advancing to the next living player).
 - `isGameOver(): boolean` — true when only one player is alive or the draw pile
   is exhausted.
 - `getWinnerId(): int` — the winner's id; throws `IllegalStateException`

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -144,6 +144,32 @@
   (`gameEngine.notOver`) if the game is not over. Last player standing, or — on
   an exhausted pile — the living player with the most cards (ties: lowest id).
 
+### UI turn flow (recommended call sequence)
+
+For each turn the UI drives the engine as follows:
+
+1. Show `getPlayerHand(getCurrentPlayerId())` and `getDiscardPile()`.
+2. While the current player chooses to play cards, call the matching
+   `play*` method (e.g. `playSkip`, `playAttack`, `playFavor`). Each returns
+   after validating; catch `IllegalArgumentException` / `IllegalStateException`
+   and show the message (resolve the key against the locale bundle).
+   - `playSkip`, `playReverse`, `playAttack`, `playTargetedAttack` end the turn
+     themselves — after them, go to step 5.
+3. When the player chooses to draw, check `isDeckEmpty()`; if empty the game is
+   over (`isGameOver()`), go to step 6.
+4. Call `drawCardForCurrentPlayer()`.
+   - If the drawn card is `EXPLODING_KITTEN`: call `defuseDrawnKitten(index)`
+     when the player has (and plays) a Defuse, otherwise `explodeCurrentPlayer()`.
+     Both end the turn.
+   - Otherwise call `endTurnByDrawing()` to end the turn (honours Attack
+     stacking and skips eliminated players).
+5. After any turn-ending action, check `isGameOver()`; if true call
+   `getWinnerId()` and show the End screen.
+6. Otherwise repeat from step 1 for the new `getCurrentPlayerId()`.
+
+A Nope may be played by any other player via `playNope(noperId)` immediately
+after a card is played, before the next action.
+
 ---
 
 ## ActionController Class

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -110,6 +110,28 @@
 
 ## ActionController Class
 
+Applies the deck/player-level effect of a played card. Stateless apart from an
+injected `Random` (so the Cat-pair random steal is deterministic under test).
+Turn-flow effects that change *whose* turn it is or *how many* turns are owed
+(Skip, Attack, Targeted Attack) live in `GameEngine`, since they manipulate its
+turn-state; `ActionController` only touches the deck and players' hands.
+
+### Data Members
+- `random`: `Random` — source of randomness for `stealRandomCard`.
+
+### Methods
+- `ActionController()` — production constructor; uses `new Random()`.
+- `ActionController(Random random)` — package-private; injects a seeded
+  `Random` for deterministic tests.
+- `shuffleDeck(Deck deck)` — `deck.shuffle()` (Shuffle card).
+- `peekTopThree(Deck deck): List<Card>` — top up to 3 cards (See the Future);
+  returns fewer when the draw pile is smaller; no state change.
+- `reverseDirection(TurnTracker turnTracker)` — `turnTracker.changeCurrentDirection()`
+  (Reverse card).
+- `giveCard(Player from, Player to, int cardIndex)` — Favor: removes the card at
+  `cardIndex` from `from`'s hand and adds it to `to`'s hand.
+- `stealRandomCard(Player from, Player to)` — Cat pair: moves one randomly
+  chosen card from `from`'s hand to `to`'s hand; no-op if `from` has no cards.
 
 ---
 

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -47,6 +47,8 @@
 - `NOPE`
 - `CAT_CARDS`
 - `FAVOR`
+- `REVERSE`
+- `TARGETED_ATTACK`
 
 ---
 

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -138,6 +138,23 @@
 
 ## RuleManager Class
 
+Pure, stateless validation of whether a play is legal in the current state.
+Each method throws (with an i18n key) when the play is illegal and returns
+normally otherwise. No mutation; takes domain objects as parameters so it is
+trivially unit-testable.
+
+### Methods
+- `requirePlayable(CardType type)` — throws `IllegalArgumentException`
+  (`rule.play.cannotPlayDirectly`) if `type` is `DEFUSE` or `EXPLODING_KITTEN`
+  (those are never played directly from hand).
+- `requireValidTarget(Player actor, Player target)` — throws
+  `IllegalArgumentException` (`rule.target.invalid`) if `target` is the actor
+  themselves or is not alive.
+- `requireCatPair(Player actor)` — throws `IllegalStateException`
+  (`rule.catPair.needTwo`) if the actor holds fewer than two `CAT_CARDS`.
+- `requireSomethingToNope(CardType lastPlayedCard)` — throws
+  `IllegalStateException` (`rule.nope.nothingToCancel`) if `lastPlayedCard` is
+  `null`.
 
 ---
 

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -105,6 +105,37 @@
   `IllegalStateException` (`deck.emptyType`) if the draw pile is empty.
 - `advanceToNextPlayer()` — hands the turn to the next player via
   `TurnTracker.turnGoesToNextPlayer()`.
+- `getForcedTurns(): int` — draws the current player still owes before the turn
+  passes (1 normally; raised by Attack / Targeted Attack).
+- `getLastPlayedCard(): CardType` — the most recently played card type (what a
+  Nope may cancel); `null` before any card is played.
+- `playSkip()` — discards a SKIP from the current hand and ends one owed turn
+  without drawing.
+- `playShuffle()` — discards a SHUFFLE and shuffles the draw pile; same player
+  continues.
+- `playSeeTheFuture(): List<Card>` — discards a SEE_THE_FUTURE and returns the
+  top up-to-3 cards; same player continues.
+- `playReverse()` — discards a REVERSE, flips the turn direction, and ends one
+  owed turn without drawing.
+- `playAttack()` — discards an ATTACK and ends the current turn without drawing;
+  the next living player owes `(2 + any stacked turns)` turns.
+- `playTargetedAttack(int targetId)` — discards a TARGETED_ATTACK; like Attack
+  but the chosen living opponent (not the neighbour) owes the turns.
+- `playFavor(int targetId, int cardIndex)` — discards a FAVOR; the target gives
+  the card at `cardIndex` to the current player; same player continues.
+- `playCatPair(int targetId)` — discards two CAT_CARDS and steals one random
+  card from the target; same player continues.
+- `playNope(int noperId)` — the noper discards a NOPE to cancel the last played
+  card (simplified, no reaction window); clears `lastPlayedCard`.
+- `defuseDrawnKitten(int reinsertIndex)` — after drawing an Exploding Kitten,
+  discards a DEFUSE, reinserts the kitten at `reinsertIndex`, and ends the turn.
+- `explodeCurrentPlayer()` — after drawing an Exploding Kitten with no Defuse,
+  marks the current player dead and ends the turn.
+- `isGameOver(): boolean` — true when only one player is alive or the draw pile
+  is exhausted.
+- `getWinnerId(): int` — the winner's id; throws `IllegalStateException`
+  (`gameEngine.notOver`) if the game is not over. Last player standing, or — on
+  an exhausted pile — the living player with the most cards (ties: lowest id).
 
 ---
 

--- a/docs/plans/2026-06-01-game-loop-design.md
+++ b/docs/plans/2026-06-01-game-loop-design.md
@@ -1,0 +1,134 @@
+# Game Loop Finalization — Design
+
+Date: 2026-06-01
+Branch: `feat/game-loop`
+
+## Goal
+
+Turn the existing setup-only `GameEngine` into a fully playable Exploding
+Kittens loop: every current card type wired in, two new card types
+(`REVERSE`, `TARGETED_ATTACK`), and a second win condition (draw pile
+exhausted) on top of last-player-standing.
+
+All player decisions arrive as **explicit method parameters** — no I/O in the
+domain, so everything is deterministic and unit-testable. The UI layer (owned
+by a teammate) calls these methods.
+
+## Class responsibilities
+
+- **`GameEngine`** — orchestrator and single entry point for a turn. Owns
+  `players`, `deck`, `turnTracker`, and turn-state (`forcedTurns`,
+  `lastPlayedCard`, pending exploding kitten). Exposes the turn API and the
+  win-condition queries. Delegates legality to `RuleManager` and effects to
+  `ActionController`.
+- **`RuleManager`** — pure, stateless validation. Answers "is this play legal
+  in this state?" and throws `IllegalStateException` / `IllegalArgumentException`
+  with an i18n key when not. No mutation.
+- **`ActionController`** — applies a validated card's effect by mutating game
+  state. Takes an injected `Random` (package-private constructor) so the
+  Cat-pair random steal is deterministic under test.
+
+Per-play flow: `GameEngine.playCard*` → `RuleManager.validate*` (throws if
+illegal) → `ActionController.apply*` (mutates) → `GameEngine` updates
+turn/win state and records `lastPlayedCard`.
+
+## Turn state
+
+- `forcedTurns` (int, default 1) — draws the current player still owes. Attack
+  and Targeted Attack set the *next/target* player's count (stacking: owed N →
+  next owes N + 2).
+- `lastPlayedCard` (CardType, nullable) — the only thing a Nope can cancel.
+- `pendingKitten` (Card, nullable) — an exploding kitten just drawn, awaiting
+  defuse-or-die resolution.
+
+### A single turn
+
+1. Current player plays zero or more cards (`playSkip`, `playAttack`, ...).
+   Each play: validate → apply → record `lastPlayedCard`.
+2. Player ends the turn by drawing (`drawCardForCurrentPlayer()`):
+   - Exploding Kitten → set `pendingKitten`; caller resolves via
+     `defuseAndReinsert(index)` or `resolveExplosionWithoutDefuse()`.
+   - Otherwise the card stays in hand and the turn ends.
+3. Decrement `forcedTurns`. If > 0, same player goes again. If 0,
+   `advanceToNextPlayer()` (skipping dead players) and reset `forcedTurns`.
+
+Skip and Attack and Reverse end the turn **without** drawing.
+
+## Card-by-card behavior
+
+| Card | Method | Effect |
+|------|--------|--------|
+| Skip | `playSkip()` | End turn, no draw; consume one forced turn. |
+| Shuffle | `playShuffle()` | `deck.shuffle()`; same player continues. |
+| See the Future | `playSeeTheFuture(): List<Card>` | Return `deck.peekTop(3)` copy (fewer if pile smaller); no state change. |
+| Attack | `playAttack()` | End turn no-draw; next player owes current + 2 turns. |
+| Reverse | `playReverse()` | `turnTracker.changeCurrentDirection()`; ends turn like Skip. |
+| Favor | `playFavor(targetId, cardIndex)` | Target gives the chosen card to current player. |
+| Targeted Attack | `playTargetedAttack(targetId)` | Like Attack, but `targetId` owes the turns. |
+| Cat pair | `playCatPair(targetId)` | Requires 2 matching `CAT_CARDS`; steal a random card from target. |
+| Nope | `playNope(noperId)` | Cancel `lastPlayedCard`'s effect (simplified, no reaction window). |
+| Defuse | resolved on draw | `defuseAndReinsert(index)`. |
+
+### RuleManager rejections
+
+- Playing `DEFUSE` or `EXPLODING_KITTEN` directly.
+- Favor / Targeted Attack / Cat pair with an invalid, dead, or self target.
+- Cat pair without two matching `CAT_CARDS` in hand.
+- Nope when `lastPlayedCard` is null (nothing to cancel).
+
+## Explode / Defuse resolution
+
+`drawCardForCurrentPlayer()` returns the drawn card. If it is an Exploding
+Kitten, the engine stores it as `pendingKitten` and the caller resolves:
+
+1. **No Defuse** → `resolveExplosionWithoutDefuse()` → `player.markDead()`,
+   kitten to discard, advance to next living player.
+2. **Has Defuse** → `defuseAndReinsert(index)` → remove one Defuse from hand to
+   discard, `deck.insertAt(kitten, index)`, end turn, advance.
+
+## Win conditions
+
+Checked after each turn-ending event:
+
+1. **Last player standing** — `countAlive() == 1` → that player wins.
+2. **Draw pile exhausted** — `deck.isEmpty()` with >= 2 alive → winner is the
+   living player with the **most cards in hand**, ties broken by **lowest
+   player id**.
+
+API: `isGameOver(): boolean`, `getWinnerId(): int` (throws `game.notOver` when
+the game is not over). `advanceToNextPlayer()` skips dead players.
+
+## New CardType values
+
+`REVERSE`, `TARGETED_ATTACK` appended to the enum. `Deck` constructor gains
+counts (4 REVERSE, 3 TARGETED_ATTACK) which shift the setup draw-pile
+constants; recompute and update GameEngine setup tests/BVA.
+
+## i18n keys (en + zh)
+
+- `rule.play.cannotPlayDirectly`
+- `rule.target.invalid`
+- `rule.catPair.needTwo`
+- `rule.nope.nothingToCancel`
+- `game.notOver`
+
+## Mocking
+
+`ActionController` takes a `Random` via a package-private constructor;
+production uses `new Random()`, tests inject a seeded `Random` for a
+deterministic Cat-pair steal. No new build dependency.
+
+## Implementation order (each step = doc/BVA + Red→Green commits)
+
+1. Design doc (this file), `REVERSE` + `TARGETED_ATTACK` enum values, `Deck`
+   counts + recomputed setup constants.
+2. `RuleManager` validation methods (pure).
+3. `ActionController` effects — non-interactive first (Skip, Shuffle, Reverse,
+   See the Future, Attack), then interactive (Favor, Targeted Attack, Cat pair).
+4. `GameEngine` turn-state, `playCard*` dispatch, explode/defuse resolution,
+   living-player advance.
+5. Win conditions (`isGameOver` / `getWinnerId`).
+6. Nope (simplified) last.
+
+Standards: per-method Red→Green commits, design-doc + BVA updated alongside
+code, sole authorship, i18n keys (no hard-coded user strings), Clean Code.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -262,3 +262,232 @@ Postconditions:
 - The current player has drawn exactly one card (unless the pile was empty).
 - The hand shown to each player is a snapshot that cannot be edited from outside the game.
 - The turn has passed to the next player, or the game has ended.
+---
+
+## Use Case 9: Play Skip
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least one Skip card.
+
+Main Flow:
+
+1. Player selects Skip from their hand.
+2. System places the Skip on the discard pile.
+3. System ends one of the player's owed turns without making them draw.
+4. If the player owes no more turns, system advances to the next living player.
+
+Alternate Flows:
+
+4.a The player was under an Attack and still owes one or more turns.
+  4.a.1 System keeps the turn with the same player for their remaining owed turn(s).
+
+Postconditions:
+
+- The Skip card is in the discard pile.
+- The player did not draw a card for the skipped turn.
+- The turn has advanced only if no owed turns remain.
+
+---
+
+## Use Case 10: Play Shuffle
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least one Shuffle card.
+
+Main Flow:
+
+1. Player selects Shuffle from their hand.
+2. System places the Shuffle on the discard pile.
+3. System randomly reorders the draw pile.
+4. System returns to the play-or-pass prompt for the same player.
+
+Postconditions:
+
+- The Shuffle card is in the discard pile.
+- The draw pile contains the same cards in a new random order.
+- It is still the same player's turn.
+
+---
+
+## Use Case 11: Play Reverse
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least one Reverse card.
+
+Main Flow:
+
+1. Player selects Reverse from their hand.
+2. System places the Reverse on the discard pile.
+3. System flips the direction of play (forward becomes backward and vice versa).
+4. System ends one owed turn without making the player draw, then advances in the new direction if no owed turns remain.
+
+Postconditions:
+
+- The Reverse card is in the discard pile.
+- The direction of play is flipped.
+- The turn has advanced in the new direction (unless the player still owes turns).
+
+---
+
+## Use Case 12: Play a Targeted Attack
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least one Targeted Attack card.
+
+Main Flow:
+
+1. Player selects Targeted Attack and chooses a living opponent.
+2. System places the Targeted Attack on the discard pile.
+3. System ends the current player's turn without requiring a draw.
+4. System makes the chosen opponent the current player and forces them to take two consecutive turns.
+
+Alternate Flows:
+
+1.a The chosen target is the player themselves or is already eliminated.
+  1.a.1 System rejects the choice (`rule.target.invalid`) and resumes at step 1.
+
+4.a The current player was already serving a stacked Attack with N turns remaining.
+  4.a.1 System transfers the remaining N turns to the chosen target and adds 2 more.
+
+Postconditions:
+
+- The Targeted Attack card is in the discard pile.
+- The chosen opponent is now the current player and owes the correct number of forced turns.
+
+---
+
+## Use Case 13: Play Favor
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least one Favor card.
+
+Main Flow:
+
+1. Player selects Favor and chooses a living opponent.
+2. System places the Favor on the discard pile.
+3. System takes the chosen card from the target's hand and gives it to the current player.
+4. System returns to the play-or-pass prompt for the same player.
+
+Alternate Flows:
+
+1.a The chosen target is the player themselves or is already eliminated.
+  1.a.1 System rejects the choice (`rule.target.invalid`) and resumes at step 1.
+
+Postconditions:
+
+- The Favor card is in the discard pile.
+- One card has moved from the target's hand to the current player's hand.
+- It is still the same player's turn.
+
+---
+
+## Use Case 14: Play a Pair of Cat Cards
+
+Actor: Current Player
+
+Preconditions:
+
+- It is the current player's turn.
+- The player's hand contains at least two matching Cat cards.
+
+Main Flow:
+
+1. Player selects a matching pair of Cat cards and chooses a living opponent.
+2. System places both Cat cards on the discard pile.
+3. System takes one card chosen at random from the target's hand and gives it to the current player.
+4. System returns to the play-or-pass prompt for the same player.
+
+Alternate Flows:
+
+1.a The player does not hold two matching Cat cards.
+  1.a.1 System rejects the play (`rule.catPair.needTwo`) and resumes at the play-or-pass prompt.
+
+1.b The chosen target is the player themselves or is already eliminated.
+  1.b.1 System rejects the choice (`rule.target.invalid`) and resumes at step 1.
+
+3.a The target has no cards.
+  3.a.1 System steals nothing; the play still consumed the pair.
+
+Postconditions:
+
+- Both Cat cards are in the discard pile.
+- At most one random card has moved from the target to the current player.
+- It is still the same player's turn.
+
+---
+
+## Use Case 15: Nope a Played Card
+
+Actor: Any Player (other than the one who just played)
+
+Preconditions:
+
+- A card was just played and its effect is the most recent action.
+- The noping player's hand contains at least one Nope card.
+
+Main Flow:
+
+1. Player chooses to play a Nope in response to the last played card.
+2. System places the Nope on the discard pile.
+3. System cancels the last played card so it can no longer be noped again.
+
+Alternate Flows:
+
+1.a There is no recently played card to cancel.
+  1.a.1 System rejects the play (`rule.nope.nothingToCancel`).
+
+1.b The player does not hold a Nope card.
+  1.b.1 System rejects the play (`gameEngine.play.notInHand`).
+
+Postconditions:
+
+- The Nope card is in the discard pile.
+- There is no longer a pending played card to nope.
+
+---
+
+## Use Case 16: End Game by Exhausted Draw Pile
+
+Actor: System
+
+Preconditions:
+
+- A game is in progress.
+- The draw pile has just become empty while two or more players are still alive.
+
+Main Flow:
+
+1. System detects that the draw pile is empty.
+2. System compares the hand sizes of all living players.
+3. System declares the living player holding the most cards the winner.
+4. System transitions to the End Screen, showing the winner.
+
+Alternate Flows:
+
+2.a Two or more living players are tied for the most cards.
+  2.a.1 System breaks the tie in favor of the lowest player id.
+
+Postconditions:
+
+- The game is no longer accepting turn actions.
+- The winner (most cards, lowest id on a tie) is displayed.

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -19,7 +19,7 @@ Main Flow:
 3. Player enters the number of players (2–5).
 4. System creates one player seat per requested player, numbered 0..N-1.
 5. System sets aside all 4 Exploding Kittens and all 6 Defuses from the full deck.
-6. System shuffles the remaining 46 non-Exploding-Kitten, non-Defuse cards.
+6. System shuffles the remaining 53 non-Exploding-Kitten, non-Defuse cards.
 7. System deals each player 4 cards from that shuffled pool plus 1 Defuse, for a starting hand of 5 cards.
 8. System returns the unused (6 − N) Defuses and (N − 1) Exploding Kittens to the draw pile.
 9. System shuffles the draw pile.
@@ -34,7 +34,7 @@ Alternate Flows:
 Postconditions:
 
 - Each of the N players has exactly 5 cards in hand, including a Defuse and no Exploding Kitten.
-- The draw pile holds (46 − 4·N) random cards + (6 − N) Defuses + (N − 1) Exploding Kittens, shuffled — 43 cards for 2 players, 31 cards for 5 players.
+- The draw pile holds (53 − 4·N) random cards + (6 − N) Defuses + (N − 1) Exploding Kittens, shuffled — 50 cards for 2 players, 38 cards for 5 players.
 - The game is ready for the first turn, starting with player 0.
 
 ---

--- a/docs/weekly-reports/report.md
+++ b/docs/weekly-reports/report.md
@@ -40,8 +40,9 @@
 2. [done] Allan: started game implementation (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/39)
 3. [in progress] Allan: started TurnTracker class
 
-# Week X (XX/XX/2026-XX/XX/2026) TEMPLATE (You can change the format to whatever the team likes better)
+# Week 10 (06/01/2026-06/07/2026)
 **Planning and Progress Tracking**:
-1. [done] Person: Task (Links to PR)
-2. [not started] Person: Task (Links to PR)
-3. [80% done] Person: Task (Links to PR)
+1. [done] Kevin: Refactored `Player` to match the design-doc API (`int playerId`, `List<Card>` hand, `getCardAt`/`getHand`/`getIndexOfCard`/`markDead`, all error strings i18n-keyed) and built the `GameEngine` setup phase (validate 2–5 players, deal 5-card hands, rig the deck with Exploding Kittens/Defuses). Per-method Red→Green TDD with BVA (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/43)
+2. [done] Kevin: Added UI-facing `GameEngine` methods for the UI developer — `isDeckEmpty`, `getPlayerHand` (defensive copy via new `Player.getHand`), `drawCardForCurrentPlayer`, `advanceToNextPlayer`; TDD + design-doc + BVA (https://github.com/nu-cs-sqe/course-project-20252603-team-19-20252603-2/pull/48)
+3. [done] Kevin: Set up PIT mutation testing (`info.solidsoft.pitest`) wired into `./gradlew build`, mirroring the Code-Coverage lab; first run reports 95% test strength (branch `setup/pitest`). TurnTracker `changeCurrentDirection` shows as the lone uncovered method — flagged for Allan
+4. [done] Kevin: Finalized the playable game loop on `feat/game-loop` — new `REVERSE` + `TARGETED_ATTACK` card types dealt from the deck (size 63), `RuleManager` legality checks, `ActionController` effects (shuffle, see-the-future, reverse, favor, cat-pair steal with injected `Random`), all `GameEngine` play methods (skip/shuffle/see-the-future/reverse/attack/targeted-attack/favor/cat-pair/nope), explode-or-defuse resolution, and two win conditions (last player standing + draw-pile exhausted). Per-method Red→Green TDD; design-doc, BVA, and use-cases updated alongside

--- a/src/main/java/domain/ActionController.java
+++ b/src/main/java/domain/ActionController.java
@@ -1,4 +1,46 @@
 package domain;
 
-public class ActionController {
+import java.util.List;
+import java.util.Random;
+
+public final class ActionController {
+
+    private static final int SEE_THE_FUTURE_COUNT = 3;
+
+    private final Random random;
+
+    public ActionController() {
+        this(new Random());
+    }
+
+    ActionController(Random random) {
+        this.random = random;
+    }
+
+    public void shuffleDeck(Deck deck) {
+        deck.shuffle();
+    }
+
+    public List<Card> peekTopThree(Deck deck) {
+        int count = Math.min(SEE_THE_FUTURE_COUNT, deck.getSize());
+        return deck.peekTop(count);
+    }
+
+    public void reverseDirection(TurnTracker turnTracker) {
+        turnTracker.changeCurrentDirection();
+    }
+
+    public void giveCard(Player from, Player to, int cardIndex) {
+        Card given = from.removeCardFromHand(cardIndex);
+        to.addCardToHand(given);
+    }
+
+    public void stealRandomCard(Player from, Player to) {
+        if (from.getHandSize() == 0) {
+            return;
+        }
+        int index = random.nextInt(from.getHandSize());
+        Card stolen = from.removeCardFromHand(index);
+        to.addCardToHand(stolen);
+    }
 }

--- a/src/main/java/domain/CardType.java
+++ b/src/main/java/domain/CardType.java
@@ -9,5 +9,7 @@ public enum CardType {
 	SEE_THE_FUTURE,
 	NOPE,
 	CAT_CARDS,
-	FAVOR
+	FAVOR,
+	REVERSE,
+	TARGETED_ATTACK
 }

--- a/src/main/java/domain/Deck.java
+++ b/src/main/java/domain/Deck.java
@@ -13,9 +13,11 @@ public class Deck {
 	private static final int numberOfSeeTheFutures = 5;
 	private static final int numberOfNopes = 5;
 	private static final int numberOfFavors = 4;
+	private static final int numberOfReverses = 4;
+	private static final int numberOfTargetedAttacks = 3;
 	private static final int numberOfCatCards = 20;
 
-	private static final int deckSize = 56;
+	private static final int deckSize = 63;
 
 	private static final String EMPTY_DECK_TYPE_KEY = "deck.emptyType";
 	private static final String PEEK_TOP_TOO_MANY_KEY = "deck.peekTop.tooManyRequested";
@@ -44,6 +46,8 @@ public class Deck {
 		addCards(CardType.SEE_THE_FUTURE, numberOfSeeTheFutures);
 		addCards(CardType.NOPE, numberOfNopes);
 		addCards(CardType.FAVOR, numberOfFavors);
+		addCards(CardType.REVERSE, numberOfReverses);
+		addCards(CardType.TARGETED_ATTACK, numberOfTargetedAttacks);
 		addCards(CardType.CAT_CARDS, numberOfCatCards);
 	}
 

--- a/src/main/java/domain/GameEngine.java
+++ b/src/main/java/domain/GameEngine.java
@@ -178,6 +178,17 @@ public final class GameEngine {
         forcedTurns = NORMAL_FORCED_TURNS;
     }
 
+    public void playNope(int noperId) {
+        ruleManager.requireSomethingToNope(lastPlayedCard);
+        Player noper = getPlayer(noperId);
+        int index = noper.getIndexOfCard(CardType.NOPE);
+        if (index < 0) {
+            throw new IllegalStateException(NOT_IN_HAND_KEY);
+        }
+        deck.discard(noper.removeCardFromHand(index));
+        lastPlayedCard = null;
+    }
+
     public boolean isGameOver() {
         return countAlive() == 1 || deck.isEmpty();
     }

--- a/src/main/java/domain/GameEngine.java
+++ b/src/main/java/domain/GameEngine.java
@@ -16,6 +16,8 @@ public final class GameEngine {
     private static final String NUM_PLAYERS_OUT_OF_RANGE_KEY = "gameEngine.numPlayers.outOfRange";
     private static final String INVALID_PLAYER_ID_KEY = "gameEngine.getPlayer.invalidId";
     private static final String NOT_IN_HAND_KEY = "gameEngine.play.notInHand";
+    private static final String NO_KITTEN_KEY = "gameEngine.defuse.noKitten";
+    private static final String NO_DEFUSE_KEY = "gameEngine.defuse.noDefuse";
 
     private final int numPlayers;
     private final List<Player> players;
@@ -117,6 +119,67 @@ public final class GameEngine {
         int transferred = forcedTurns == NORMAL_FORCED_TURNS ? 0 : forcedTurns;
         advanceToNextLivingPlayer();
         forcedTurns = transferred + TURNS_ADDED_BY_ATTACK;
+    }
+
+    public void playTargetedAttack(int targetId) {
+        Player current = getPlayer(getCurrentPlayerId());
+        Player target = getPlayer(targetId);
+        ruleManager.requireValidTarget(current, target);
+        playFromHand(CardType.TARGETED_ATTACK);
+        int transferred = forcedTurns == NORMAL_FORCED_TURNS ? 0 : forcedTurns;
+        turnTracker.setCurrentPlayer(targetId);
+        forcedTurns = transferred + TURNS_ADDED_BY_ATTACK;
+    }
+
+    public void playFavor(int targetId, int cardIndex) {
+        Player current = getPlayer(getCurrentPlayerId());
+        Player target = getPlayer(targetId);
+        ruleManager.requireValidTarget(current, target);
+        playFromHand(CardType.FAVOR);
+        actionController.giveCard(target, current, cardIndex);
+    }
+
+    public void playCatPair(int targetId) {
+        Player current = getPlayer(getCurrentPlayerId());
+        Player target = getPlayer(targetId);
+        ruleManager.requireValidTarget(current, target);
+        ruleManager.requireCatPair(current);
+        discardOneFromCurrent(CardType.CAT_CARDS);
+        discardOneFromCurrent(CardType.CAT_CARDS);
+        lastPlayedCard = CardType.CAT_CARDS;
+        actionController.stealRandomCard(target, current);
+    }
+
+    public void defuseDrawnKitten(int reinsertIndex) {
+        Player current = getPlayer(getCurrentPlayerId());
+        int kittenIndex = current.getIndexOfCard(CardType.EXPLODING_KITTEN);
+        if (kittenIndex < 0) {
+            throw new IllegalStateException(NO_KITTEN_KEY);
+        }
+        if (current.getIndexOfCard(CardType.DEFUSE) < 0) {
+            throw new IllegalStateException(NO_DEFUSE_KEY);
+        }
+        Card kitten = current.removeCardFromHand(kittenIndex);
+        deck.discard(current.removeCardFromHand(current.getIndexOfCard(CardType.DEFUSE)));
+        deck.insertAt(kitten, reinsertIndex);
+        consumeOneForcedTurn();
+    }
+
+    public void explodeCurrentPlayer() {
+        Player current = getPlayer(getCurrentPlayerId());
+        int kittenIndex = current.getIndexOfCard(CardType.EXPLODING_KITTEN);
+        if (kittenIndex < 0) {
+            throw new IllegalStateException(NO_KITTEN_KEY);
+        }
+        deck.discard(current.removeCardFromHand(kittenIndex));
+        current.markDead();
+        advanceToNextLivingPlayer();
+        forcedTurns = NORMAL_FORCED_TURNS;
+    }
+
+    private void discardOneFromCurrent(CardType type) {
+        Player current = getPlayer(getCurrentPlayerId());
+        deck.discard(current.removeCardFromHand(current.getIndexOfCard(type)));
     }
 
     private void playFromHand(CardType type) {

--- a/src/main/java/domain/GameEngine.java
+++ b/src/main/java/domain/GameEngine.java
@@ -83,7 +83,15 @@ public final class GameEngine {
     }
 
     public void advanceToNextPlayer() {
-        turnTracker.turnGoesToNextPlayer();
+        advanceToNextLivingPlayer();
+    }
+
+    public void endTurnByDrawing() {
+        consumeOneForcedTurn();
+    }
+
+    public List<Card> getDiscardPile() {
+        return deck.getDiscardPile();
     }
 
     public int getForcedTurns() {
@@ -174,6 +182,9 @@ public final class GameEngine {
         }
         deck.discard(current.removeCardFromHand(kittenIndex));
         current.markDead();
+        while (current.getHandSize() > 0) {
+            deck.discard(current.removeCardFromHand(0));
+        }
         advanceToNextLivingPlayer();
         forcedTurns = NORMAL_FORCED_TURNS;
     }

--- a/src/main/java/domain/GameEngine.java
+++ b/src/main/java/domain/GameEngine.java
@@ -18,6 +18,7 @@ public final class GameEngine {
     private static final String NOT_IN_HAND_KEY = "gameEngine.play.notInHand";
     private static final String NO_KITTEN_KEY = "gameEngine.defuse.noKitten";
     private static final String NO_DEFUSE_KEY = "gameEngine.defuse.noDefuse";
+    private static final String NOT_OVER_KEY = "gameEngine.notOver";
 
     private final int numPlayers;
     private final List<Player> players;
@@ -175,6 +176,35 @@ public final class GameEngine {
         current.markDead();
         advanceToNextLivingPlayer();
         forcedTurns = NORMAL_FORCED_TURNS;
+    }
+
+    public boolean isGameOver() {
+        return countAlive() == 1 || deck.isEmpty();
+    }
+
+    public int getWinnerId() {
+        if (!isGameOver()) {
+            throw new IllegalStateException(NOT_OVER_KEY);
+        }
+        int winnerId = -1;
+        int mostCards = -1;
+        for (Player player : players) {
+            if (player.isAlive() && player.getHandSize() > mostCards) {
+                mostCards = player.getHandSize();
+                winnerId = player.getPlayerId();
+            }
+        }
+        return winnerId;
+    }
+
+    private int countAlive() {
+        int alive = 0;
+        for (Player player : players) {
+            if (player.isAlive()) {
+                alive++;
+            }
+        }
+        return alive;
     }
 
     private void discardOneFromCurrent(CardType type) {

--- a/src/main/java/domain/GameEngine.java
+++ b/src/main/java/domain/GameEngine.java
@@ -10,14 +10,22 @@ public final class GameEngine {
     private static final int MAX_PLAYERS = 5;
     private static final int INITIAL_NON_DEFUSE_CARDS_PER_PLAYER = 4;
     private static final int TOTAL_DEFUSES = 6;
+    private static final int NORMAL_FORCED_TURNS = 1;
+    private static final int TURNS_ADDED_BY_ATTACK = 2;
 
     private static final String NUM_PLAYERS_OUT_OF_RANGE_KEY = "gameEngine.numPlayers.outOfRange";
     private static final String INVALID_PLAYER_ID_KEY = "gameEngine.getPlayer.invalidId";
+    private static final String NOT_IN_HAND_KEY = "gameEngine.play.notInHand";
 
     private final int numPlayers;
     private final List<Player> players;
     private final TurnTracker turnTracker;
     private final Deck deck;
+    private final RuleManager ruleManager;
+    private final ActionController actionController;
+
+    private int forcedTurns = NORMAL_FORCED_TURNS;
+    private CardType lastPlayedCard;
 
     public GameEngine(int numPlayers) {
         if (numPlayers < MIN_PLAYERS || numPlayers > MAX_PLAYERS) {
@@ -30,6 +38,8 @@ public final class GameEngine {
         }
         this.turnTracker = new TurnTracker();
         this.turnTracker.setNumTotalPlayers(numPlayers);
+        this.ruleManager = new RuleManager();
+        this.actionController = new ActionController();
 
         List<Card> nonSpecialPool = buildShuffledNonSpecialPool();
         dealStartingHands(this.players, nonSpecialPool);
@@ -71,6 +81,67 @@ public final class GameEngine {
 
     public void advanceToNextPlayer() {
         turnTracker.turnGoesToNextPlayer();
+    }
+
+    public int getForcedTurns() {
+        return forcedTurns;
+    }
+
+    public CardType getLastPlayedCard() {
+        return lastPlayedCard;
+    }
+
+    public void playSkip() {
+        playFromHand(CardType.SKIP);
+        consumeOneForcedTurn();
+    }
+
+    public void playShuffle() {
+        playFromHand(CardType.SHUFFLE);
+        actionController.shuffleDeck(deck);
+    }
+
+    public List<Card> playSeeTheFuture() {
+        playFromHand(CardType.SEE_THE_FUTURE);
+        return actionController.peekTopThree(deck);
+    }
+
+    public void playReverse() {
+        playFromHand(CardType.REVERSE);
+        actionController.reverseDirection(turnTracker);
+        consumeOneForcedTurn();
+    }
+
+    public void playAttack() {
+        playFromHand(CardType.ATTACK);
+        int transferred = forcedTurns == NORMAL_FORCED_TURNS ? 0 : forcedTurns;
+        advanceToNextLivingPlayer();
+        forcedTurns = transferred + TURNS_ADDED_BY_ATTACK;
+    }
+
+    private void playFromHand(CardType type) {
+        ruleManager.requirePlayable(type);
+        Player current = getPlayer(getCurrentPlayerId());
+        int index = current.getIndexOfCard(type);
+        if (index < 0) {
+            throw new IllegalStateException(NOT_IN_HAND_KEY);
+        }
+        deck.discard(current.removeCardFromHand(index));
+        lastPlayedCard = type;
+    }
+
+    private void consumeOneForcedTurn() {
+        forcedTurns--;
+        if (forcedTurns <= 0) {
+            advanceToNextLivingPlayer();
+            forcedTurns = NORMAL_FORCED_TURNS;
+        }
+    }
+
+    private void advanceToNextLivingPlayer() {
+        do {
+            turnTracker.turnGoesToNextPlayer();
+        } while (!getPlayer(getCurrentPlayerId()).isAlive());
     }
 
     private static List<Card> buildShuffledNonSpecialPool() {

--- a/src/main/java/domain/RuleManager.java
+++ b/src/main/java/domain/RuleManager.java
@@ -1,4 +1,41 @@
 package domain;
 
-public class RuleManager {
+public final class RuleManager {
+
+    private static final int CAT_PAIR_SIZE = 2;
+
+    private static final String CANNOT_PLAY_DIRECTLY_KEY = "rule.play.cannotPlayDirectly";
+    private static final String INVALID_TARGET_KEY = "rule.target.invalid";
+    private static final String CAT_PAIR_NEED_TWO_KEY = "rule.catPair.needTwo";
+    private static final String NOTHING_TO_NOPE_KEY = "rule.nope.nothingToCancel";
+
+    public void requirePlayable(CardType type) {
+        if (type == CardType.DEFUSE || type == CardType.EXPLODING_KITTEN) {
+            throw new IllegalArgumentException(CANNOT_PLAY_DIRECTLY_KEY);
+        }
+    }
+
+    public void requireValidTarget(Player actor, Player target) {
+        if (target.getPlayerId() == actor.getPlayerId() || !target.isAlive()) {
+            throw new IllegalArgumentException(INVALID_TARGET_KEY);
+        }
+    }
+
+    public void requireCatPair(Player actor) {
+        int catCount = 0;
+        for (Card card : actor.getHand()) {
+            if (card.getCardType() == CardType.CAT_CARDS) {
+                catCount++;
+            }
+        }
+        if (catCount < CAT_PAIR_SIZE) {
+            throw new IllegalStateException(CAT_PAIR_NEED_TWO_KEY);
+        }
+    }
+
+    public void requireSomethingToNope(CardType lastPlayedCard) {
+        if (lastPlayedCard == null) {
+            throw new IllegalStateException(NOTHING_TO_NOPE_KEY);
+        }
+    }
 }

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -22,3 +22,7 @@ rule.play.cannotPlayDirectly = this card cannot be played directly
 rule.target.invalid = the chosen target is not a valid living opponent
 rule.catPair.needTwo = playing a cat pair needs two matching cat cards
 rule.nope.nothingToCancel = there is nothing to nope right now
+gameEngine.play.notInHand = the current player does not hold that card
+gameEngine.defuse.noKitten = the current player has no exploding kitten to defuse
+gameEngine.defuse.noDefuse = the current player has no defuse card
+gameEngine.notOver = the game is not over yet

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -18,3 +18,7 @@ player.removeCardFromHand.invalidIndex = card index is out of range
 player.markDead.alreadyDead = player is already dead
 gameEngine.numPlayers.outOfRange = number of players must be between 2 and 5
 gameEngine.getPlayer.invalidId = player id is out of range
+rule.play.cannotPlayDirectly = this card cannot be played directly
+rule.target.invalid = the chosen target is not a valid living opponent
+rule.catPair.needTwo = playing a cat pair needs two matching cat cards
+rule.nope.nothingToCancel = there is nothing to nope right now

--- a/src/main/resources/message_zh.properties
+++ b/src/main/resources/message_zh.properties
@@ -17,3 +17,7 @@ player.removeCardFromHand.invalidIndex = 卡片索引超出范围
 player.markDead.alreadyDead = 玩家已经死亡
 gameEngine.numPlayers.outOfRange = 玩家人数必须在 2 到 5 之间
 gameEngine.getPlayer.invalidId = 玩家编号超出范围
+rule.play.cannotPlayDirectly = 这张牌不能直接打出
+rule.target.invalid = 所选目标不是有效的存活对手
+rule.catPair.needTwo = 打出猫对需要两张相同的猫牌
+rule.nope.nothingToCancel = 现在没有可以否决的对象

--- a/src/main/resources/message_zh.properties
+++ b/src/main/resources/message_zh.properties
@@ -21,3 +21,7 @@ rule.play.cannotPlayDirectly = 这张牌不能直接打出
 rule.target.invalid = 所选目标不是有效的存活对手
 rule.catPair.needTwo = 打出猫对需要两张相同的猫牌
 rule.nope.nothingToCancel = 现在没有可以否决的对象
+gameEngine.play.notInHand = 当前玩家没有这张牌
+gameEngine.defuse.noKitten = 当前玩家没有需要拆除的炸弹猫
+gameEngine.defuse.noDefuse = 当前玩家没有拆弹牌
+gameEngine.notOver = 游戏还没有结束

--- a/src/test/java/domain/ActionControllerTest.java
+++ b/src/test/java/domain/ActionControllerTest.java
@@ -1,0 +1,134 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class ActionControllerTest {
+
+    private static final int FULL_DECK_SIZE = 63;
+    private static final int SEE_THE_FUTURE_COUNT = 3;
+    private final ActionController actionController = new ActionController();
+
+    @Test
+    void shuffleDeck_keepsDeckSize() {
+        Deck deck = new Deck();
+        actionController.shuffleDeck(deck);
+        assertEquals(FULL_DECK_SIZE, deck.getSize());
+    }
+
+    @Test
+    void peekTopThree_fullDeck_returnsThreeCardsWithoutChangingDeck() {
+        Deck deck = new Deck();
+        List<Card> peeked = actionController.peekTopThree(deck);
+        assertEquals(SEE_THE_FUTURE_COUNT, peeked.size());
+        assertEquals(FULL_DECK_SIZE, deck.getSize());
+    }
+
+    @Test
+    void peekTopThree_twoCardDeck_returnsTwoCards() {
+        Deck deck = makeDeck(CardType.SKIP, CardType.ATTACK);
+        assertEquals(2, actionController.peekTopThree(deck).size());
+    }
+
+    @Test
+    void peekTopThree_emptyDeck_returnsEmptyList() {
+        Deck deck = makeDeck();
+        assertEquals(0, actionController.peekTopThree(deck).size());
+    }
+
+    @Test
+    void reverseDirection_forward_becomesBackward() {
+        TurnTracker turnTracker = new TurnTracker();
+        actionController.reverseDirection(turnTracker);
+        assertEquals(-1, turnTracker.getCurrentDirection());
+    }
+
+    @Test
+    void reverseDirection_backward_becomesForward() {
+        TurnTracker turnTracker = new TurnTracker();
+        actionController.reverseDirection(turnTracker);
+        actionController.reverseDirection(turnTracker);
+        assertEquals(1, turnTracker.getCurrentDirection());
+    }
+
+    @Test
+    void giveCard_movesChosenCardFromGiverToReceiver() {
+        Player from = new Player(0);
+        Player to = new Player(1);
+        Card defuse = new Card(CardType.DEFUSE);
+        from.addCardToHand(defuse);
+
+        actionController.giveCard(from, to, 0);
+
+        assertEquals(0, from.getHandSize());
+        assertEquals(1, to.getHandSize());
+        assertSame(defuse, to.getCardAt(0));
+    }
+
+    @Test
+    void giveCard_emptyGiverHand_throwsIndexOutOfBoundsException() {
+        Player from = new Player(0);
+        Player to = new Player(1);
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> {
+                    actionController.giveCard(from, to, 0);
+                });
+    }
+
+    @Test
+    void stealRandomCard_singleCardVictim_movesThatCard() {
+        Player from = new Player(0);
+        Player to = new Player(1);
+        Card attack = new Card(CardType.ATTACK);
+        from.addCardToHand(attack);
+
+        actionController.stealRandomCard(from, to);
+
+        assertEquals(0, from.getHandSize());
+        assertSame(attack, to.getCardAt(0));
+    }
+
+    @Test
+    void stealRandomCard_manyCards_movesCardAtRandomIndex() {
+        Player from = new Player(0);
+        from.addCardToHand(new Card(CardType.SKIP));
+        Card expected = new Card(CardType.NOPE);
+        from.addCardToHand(expected);
+        from.addCardToHand(new Card(CardType.FAVOR));
+        Player to = new Player(1);
+        ActionController seeded = new ActionController(new Random() {
+            @Override
+            public int nextInt(int bound) {
+                return 1;
+            }
+        });
+
+        seeded.stealRandomCard(from, to);
+
+        assertSame(expected, to.getCardAt(0));
+        assertEquals(2, from.getHandSize());
+    }
+
+    @Test
+    void stealRandomCard_emptyVictim_isNoOp() {
+        Player from = new Player(0);
+        Player to = new Player(1);
+        actionController.stealRandomCard(from, to);
+        assertEquals(0, to.getHandSize());
+    }
+
+    private Deck makeDeck(CardType... types) {
+        List<Card> cards = new ArrayList<>();
+        for (CardType type : types) {
+            cards.add(new Card(type));
+        }
+        return new Deck(cards);
+    }
+}

--- a/src/test/java/domain/DeckTest.java
+++ b/src/test/java/domain/DeckTest.java
@@ -18,7 +18,7 @@ public class DeckTest {
 	void deck_createFullDeck_correctSize() {
 		Deck deck = new Deck();
 
-		final int fullDeckSize = 56;
+		final int fullDeckSize = 63;
 
 		List<Card> cards = deck.getDrawPile();
 
@@ -68,6 +68,8 @@ public class DeckTest {
 		final int numberOfSeeTheFuture = 5;
 		final int numberOfNope = 5;
 		final int numberOfFavor = 4;
+		final int numberOfReverse = 4;
+		final int numberOfTargetedAttack = 3;
 		final int numberOfCatCards = 20;
 
 		assertCards(cards, index, CardType.EXPLODING_KITTEN, numberOfExplodingKitten);
@@ -86,6 +88,10 @@ public class DeckTest {
 		index += numberOfNope;
 		assertCards(cards, index, CardType.FAVOR, numberOfFavor);
 		index += numberOfFavor;
+		assertCards(cards, index, CardType.REVERSE, numberOfReverse);
+		index += numberOfReverse;
+		assertCards(cards, index, CardType.TARGETED_ATTACK, numberOfTargetedAttack);
+		index += numberOfTargetedAttack;
 		assertCards(cards, index, CardType.CAT_CARDS, numberOfCatCards);
 	}
 
@@ -132,10 +138,10 @@ public class DeckTest {
 	}
 
 	@Test
-	void drawTop_fullDeck_size56_returnsCardAndBecomesSize55() {
+	void drawTop_fullDeck_size63_returnsCardAndBecomesSize62() {
 		Deck deck = new Deck();
 
-		final int expectedSize = 55;
+		final int expectedSize = 62;
 
 		Card drawn = deck.drawTop();
 
@@ -204,7 +210,7 @@ public class DeckTest {
 
 		List<Card> shuffledDeck = deck.getDrawPile();
 
-		final int expectedSize = 56;
+		final int expectedSize = 63;
 
 		assertEquals(expectedSize, shuffledDeck.size());
 
@@ -222,6 +228,8 @@ public class DeckTest {
 		final Long numberOfSeeTheFuture = 5L;
 		final Long numberOfNope = 5L;
 		final Long numberOfFavor = 4L;
+		final Long numberOfReverse = 4L;
+		final Long numberOfTargetedAttack = 3L;
 		final Long numberOfCatCards = 20L;
 
 		assertEquals(numberOfExplodingKitten, counts.get(CardType.EXPLODING_KITTEN));
@@ -232,6 +240,8 @@ public class DeckTest {
 		assertEquals(numberOfSeeTheFuture, counts.get(CardType.SEE_THE_FUTURE));
 		assertEquals(numberOfNope, counts.get(CardType.NOPE));
 		assertEquals(numberOfFavor, counts.get(CardType.FAVOR));
+		assertEquals(numberOfReverse, counts.get(CardType.REVERSE));
+		assertEquals(numberOfTargetedAttack, counts.get(CardType.TARGETED_ATTACK));
 		assertEquals(numberOfCatCards, counts.get(CardType.CAT_CARDS));
 	}
 
@@ -294,7 +304,7 @@ public class DeckTest {
 		final int n = 3;
 		List<Card> result = deck.peekTop(n);
 
-		final int expectedDeckSize = 56;
+		final int expectedDeckSize = 63;
 		final int expectedResultSize = 3;
 
 		assertEquals(expectedResultSize, result.size());
@@ -312,7 +322,7 @@ public class DeckTest {
 
 		final int n = 55;
 
-		final int expectedDeckSize = 56;
+		final int expectedDeckSize = 63;
 		final int expectedResultSize = 55;
 
 		List<Card> result = deck.peekTop(n);
@@ -330,13 +340,13 @@ public class DeckTest {
 	}
 
 	@Test
-	void peekTopIs56ReturnsAllCards() {
+	void peekTopIs63ReturnsAllCards() {
 		Deck deck = new Deck();
 
-		final int n = 56;
+		final int n = 63;
 
-		final int expectedDeckSize = 56;
-		final int expectedResultSize = 56;
+		final int expectedDeckSize = 63;
+		final int expectedResultSize = 63;
 
 		List<Card> result = deck.peekTop(n);
 
@@ -356,7 +366,7 @@ public class DeckTest {
 	void peekTopGreaterThanDeckSizeThrowsIllegalStateException() {
 		Deck deck = new Deck();
 
-		final int n = 57;
+		final int n = 64;
 
 		Exception exception = assertThrows(IllegalStateException.class, () -> {
 			deck.peekTop(n);
@@ -417,7 +427,7 @@ public class DeckTest {
 	void getSize_InitialDeck_ReturnsDeckSize() {
 		Deck deck = new Deck();
 
-		final int fullDeckSize = 56;
+		final int fullDeckSize = 63;
 		int expectedDeckSize = fullDeckSize;
 		int actualDeckSize = deck.getSize();
 
@@ -499,11 +509,11 @@ public class DeckTest {
 
 
 	@Test
-	void insertAt_InitialDeckIndex56_ReturnsTrue() {
+	void insertAt_InitialDeckIndex63_ReturnsTrue() {
 		Deck deck = new Deck();
 		Card cardToInsert = new Card(CardType.EXPLODING_KITTEN);
 
-		final int insertIndex = 56;
+		final int insertIndex = 63;
 
 		boolean expectedIsSuccess = true;
 		boolean actualIsSuccess = deck.insertAt(cardToInsert, insertIndex);
@@ -514,11 +524,11 @@ public class DeckTest {
 
 
 	@Test
-	void insertAt_InitialDeckIndex57_ThrowsException() {
+	void insertAt_InitialDeckIndex64_ThrowsException() {
 		Deck deck = new Deck();
 		Card cardToInsert = new Card(CardType.EXPLODING_KITTEN);
 
-		final int insertIndex = 57;
+		final int insertIndex = 64;
 
 		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
 			deck.insertAt(cardToInsert, insertIndex);

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -369,6 +369,17 @@ class GameEngineTest {
     }
 
     @Test
+    void playFavor_invalidCardIndex_throwsIndexOutOfBoundsException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.FAVOR);
+        final int outOfRangeIndex = engine.getPlayerHand(1).size();
+        IndexOutOfBoundsException ex = assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> engine.playFavor(1, outOfRangeIndex));
+        assertEquals("player.removeCardFromHand.invalidIndex", ex.getMessage());
+    }
+
+    @Test
     void playCatPair_stealsOneCardFromTargetAndKeepsTurn() {
         GameEngine engine = new GameEngine(MIN_PLAYERS);
         giveToCurrent(engine, CardType.CAT_CARDS);

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -549,6 +549,75 @@ class GameEngineTest {
         assertEquals("gameEngine.play.notInHand", ex.getMessage());
     }
 
+    @Test
+    void endTurnByDrawing_normalTurn_advancesToNextPlayer() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        engine.endTurnByDrawing();
+        assertEquals(1, engine.getCurrentPlayerId());
+        assertEquals(1, engine.getForcedTurns());
+    }
+
+    @Test
+    void endTurnByDrawing_underAttack_keepsSamePlayer() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.ATTACK);
+        engine.playAttack();
+        int attackedPlayer = engine.getCurrentPlayerId();
+
+        engine.endTurnByDrawing();
+
+        assertEquals(attackedPlayer, engine.getCurrentPlayerId());
+        assertEquals(1, engine.getForcedTurns());
+    }
+
+    @Test
+    void endTurnByDrawing_nextSeatDead_skipsToLivingPlayer() {
+        GameEngine engine = new GameEngine(THREE_PLAYERS);
+        engine.getPlayer(1).markDead();
+        engine.endTurnByDrawing();
+        assertEquals(2, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void advanceToNextPlayer_skipsDeadPlayer() {
+        GameEngine engine = new GameEngine(THREE_PLAYERS);
+        engine.getPlayer(1).markDead();
+        engine.advanceToNextPlayer();
+        assertEquals(2, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void getDiscardPile_atGameStart_isEmpty() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        assertEquals(0, engine.getDiscardPile().size());
+    }
+
+    @Test
+    void getDiscardPile_afterPlay_containsPlayedCard() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SKIP);
+        engine.playSkip();
+        assertEquals(1, engine.getDiscardPile().size());
+        assertEquals(CardType.SKIP, engine.getDiscardPile().get(0).getCardType());
+    }
+
+    @Test
+    void getDiscardPile_returnedListIsDefensiveCopy() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SKIP);
+        engine.playSkip();
+        engine.getDiscardPile().clear();
+        assertEquals(1, engine.getDiscardPile().size());
+    }
+
+    @Test
+    void explodeCurrentPlayer_discardsEliminatedPlayersHand() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.EXPLODING_KITTEN);
+        engine.explodeCurrentPlayer();
+        assertEquals(0, engine.getPlayer(0).getHandSize());
+    }
+
     private void giveToCurrent(GameEngine engine, CardType type) {
         engine.getPlayer(engine.getCurrentPlayerId()).addCardToHand(new Card(type));
     }

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -444,6 +444,66 @@ class GameEngineTest {
         assertEquals("gameEngine.defuse.noKitten", ex.getMessage());
     }
 
+    @Test
+    void isGameOver_atGameStart_returnsFalse() {
+        assertFalse(new GameEngine(MIN_PLAYERS).isGameOver());
+    }
+
+    @Test
+    void isGameOver_oneAlive_returnsTrue() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        engine.getPlayer(0).markDead();
+        assertTrue(engine.isGameOver());
+    }
+
+    @Test
+    void isGameOver_deckExhausted_returnsTrue() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        while (!engine.isDeckEmpty()) {
+            engine.drawCardForCurrentPlayer();
+        }
+        assertTrue(engine.isGameOver());
+    }
+
+    @Test
+    void getWinnerId_notOver_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.getWinnerId());
+        assertEquals("gameEngine.notOver", ex.getMessage());
+    }
+
+    @Test
+    void getWinnerId_lastPlayerStanding_returnsSurvivor() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        engine.getPlayer(0).markDead();
+        assertEquals(1, engine.getWinnerId());
+    }
+
+    @Test
+    void getWinnerId_deckExhausted_returnsPlayerWithMostCards() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        while (!engine.isDeckEmpty()) {
+            engine.drawCardForCurrentPlayer();
+        }
+        assertEquals(0, engine.getWinnerId());
+    }
+
+    @Test
+    void getWinnerId_deckExhaustedTie_returnsLowestId() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        while (!engine.isDeckEmpty()) {
+            engine.drawCardForCurrentPlayer();
+        }
+        Player first = engine.getPlayer(0);
+        Player second = engine.getPlayer(1);
+        while (first.getHandSize() > second.getHandSize()) {
+            first.removeCardFromHand(0);
+        }
+        assertEquals(0, engine.getWinnerId());
+    }
+
     private void giveToCurrent(GameEngine engine, CardType type) {
         engine.getPlayer(engine.getCurrentPlayerId()).addCardToHand(new Card(type));
     }

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 class GameEngineTest {
 
     private static final int MIN_PLAYERS = 2;
+    private static final int THREE_PLAYERS = 3;
     private static final int MAX_PLAYERS = 5;
     private static final int TOO_FEW = 1;
     private static final int TOO_MANY = 6;
@@ -321,6 +322,126 @@ class GameEngineTest {
 
         assertEquals(0, engine.getCurrentPlayerId());
         assertEquals(STACKED_ATTACK_FORCED_TURNS, engine.getForcedTurns());
+    }
+
+    @Test
+    void playTargetedAttack_sendsTurnToChosenTargetWithTwoForcedTurns() {
+        GameEngine engine = new GameEngine(THREE_PLAYERS);
+        giveToCurrent(engine, CardType.TARGETED_ATTACK);
+
+        engine.playTargetedAttack(2);
+
+        assertEquals(2, engine.getCurrentPlayerId());
+        assertEquals(2, engine.getForcedTurns());
+    }
+
+    @Test
+    void playTargetedAttack_self_throwsIllegalArgumentException() {
+        GameEngine engine = new GameEngine(THREE_PLAYERS);
+        giveToCurrent(engine, CardType.TARGETED_ATTACK);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> engine.playTargetedAttack(0));
+        assertEquals("rule.target.invalid", ex.getMessage());
+    }
+
+    @Test
+    void playFavor_takesCardFromTargetAndKeepsTurn() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.FAVOR);
+        int targetHandBefore = engine.getPlayerHand(1).size();
+
+        engine.playFavor(1, 0);
+
+        assertEquals(targetHandBefore - 1, engine.getPlayerHand(1).size());
+        assertEquals(0, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void playFavor_self_throwsIllegalArgumentException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.FAVOR);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> engine.playFavor(0, 0));
+        assertEquals("rule.target.invalid", ex.getMessage());
+    }
+
+    @Test
+    void playCatPair_stealsOneCardFromTargetAndKeepsTurn() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.CAT_CARDS);
+        giveToCurrent(engine, CardType.CAT_CARDS);
+        int targetHandBefore = engine.getPlayerHand(1).size();
+
+        engine.playCatPair(1);
+
+        assertEquals(targetHandBefore - 1, engine.getPlayerHand(1).size());
+        assertEquals(0, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void playCatPair_withoutTwoCats_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        clearCardType(engine.getPlayer(0), CardType.CAT_CARDS);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.playCatPair(1));
+        assertEquals("rule.catPair.needTwo", ex.getMessage());
+    }
+
+    @Test
+    void defuseDrawnKitten_survivesAndReinsertsKitten() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.EXPLODING_KITTEN);
+        final int pileBefore = engine.getDrawPileSize();
+
+        engine.defuseDrawnKitten(0);
+
+        assertTrue(engine.getPlayer(0).isAlive());
+        assertEquals(-1, engine.getPlayer(0).getIndexOfCard(CardType.EXPLODING_KITTEN));
+        assertEquals(pileBefore + 1, engine.getDrawPileSize());
+        assertEquals(1, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void defuseDrawnKitten_noKitten_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.defuseDrawnKitten(0));
+        assertEquals("gameEngine.defuse.noKitten", ex.getMessage());
+    }
+
+    @Test
+    void defuseDrawnKitten_noDefuse_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        clearCardType(engine.getPlayer(0), CardType.DEFUSE);
+        giveToCurrent(engine, CardType.EXPLODING_KITTEN);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.defuseDrawnKitten(0));
+        assertEquals("gameEngine.defuse.noDefuse", ex.getMessage());
+    }
+
+    @Test
+    void explodeCurrentPlayer_killsPlayerAndPassesTurn() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.EXPLODING_KITTEN);
+
+        engine.explodeCurrentPlayer();
+
+        assertFalse(engine.getPlayer(0).isAlive());
+        assertEquals(1, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void explodeCurrentPlayer_noKitten_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.explodeCurrentPlayer());
+        assertEquals("gameEngine.defuse.noKitten", ex.getMessage());
     }
 
     private void giveToCurrent(GameEngine engine, CardType type) {

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -15,8 +15,8 @@ class GameEngineTest {
     private static final int TOO_FEW = 1;
     private static final int TOO_MANY = 6;
     private static final int STARTING_HAND_SIZE = 5;
-    private static final int DRAW_PILE_SIZE_MIN_PLAYERS = 43;
-    private static final int DRAW_PILE_SIZE_MAX_PLAYERS = 31;
+    private static final int DRAW_PILE_SIZE_MIN_PLAYERS = 50;
+    private static final int DRAW_PILE_SIZE_MAX_PLAYERS = 38;
 
     @Test
     void constructor_minPlayers_succeeds() {
@@ -149,13 +149,13 @@ class GameEngineTest {
     }
 
     @Test
-    void getDrawPileSize_minPlayers_returns43() {
+    void getDrawPileSize_minPlayers_returns50() {
         GameEngine engine = new GameEngine(MIN_PLAYERS);
         assertEquals(DRAW_PILE_SIZE_MIN_PLAYERS, engine.getDrawPileSize());
     }
 
     @Test
-    void getDrawPileSize_maxPlayers_returns31() {
+    void getDrawPileSize_maxPlayers_returns38() {
         GameEngine engine = new GameEngine(MAX_PLAYERS);
         assertEquals(DRAW_PILE_SIZE_MAX_PLAYERS, engine.getDrawPileSize());
     }

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -15,6 +15,8 @@ class GameEngineTest {
     private static final int TOO_FEW = 1;
     private static final int TOO_MANY = 6;
     private static final int STARTING_HAND_SIZE = 5;
+    private static final int SEE_THE_FUTURE_COUNT = 3;
+    private static final int STACKED_ATTACK_FORCED_TURNS = 4;
     private static final int DRAW_PILE_SIZE_MIN_PLAYERS = 50;
     private static final int DRAW_PILE_SIZE_MAX_PLAYERS = 38;
 
@@ -242,5 +244,94 @@ class GameEngineTest {
         engine.advanceToNextPlayer();
         engine.advanceToNextPlayer();
         assertEquals(0, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void playSkip_endsTurnWithoutDrawing() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SKIP);
+        int pileBefore = engine.getDrawPileSize();
+
+        engine.playSkip();
+
+        assertEquals(1, engine.getCurrentPlayerId());
+        assertEquals(pileBefore, engine.getDrawPileSize());
+    }
+
+    @Test
+    void playSkip_withoutSkipInHand_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        clearCardType(engine.getPlayer(0), CardType.SKIP);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.playSkip());
+        assertEquals("gameEngine.play.notInHand", ex.getMessage());
+    }
+
+    @Test
+    void playShuffle_keepsSamePlayerAndDeckSize() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SHUFFLE);
+        int pileBefore = engine.getDrawPileSize();
+
+        engine.playShuffle();
+
+        assertEquals(0, engine.getCurrentPlayerId());
+        assertEquals(pileBefore, engine.getDrawPileSize());
+    }
+
+    @Test
+    void playSeeTheFuture_returnsTopThreeAndKeepsSamePlayer() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SEE_THE_FUTURE);
+
+        assertEquals(SEE_THE_FUTURE_COUNT, engine.playSeeTheFuture().size());
+        assertEquals(0, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void playReverse_flipsDirectionAndEndsTurn() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.REVERSE);
+
+        engine.playReverse();
+
+        assertEquals(1, engine.getCurrentPlayerId());
+    }
+
+    @Test
+    void playAttack_normalTurn_nextPlayerOwesTwoTurns() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.ATTACK);
+
+        engine.playAttack();
+
+        assertEquals(1, engine.getCurrentPlayerId());
+        assertEquals(2, engine.getForcedTurns());
+    }
+
+    @Test
+    void playAttack_stackedTurn_nextPlayerOwesFourTurns() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.ATTACK);
+        engine.playAttack();
+        giveToCurrent(engine, CardType.ATTACK);
+
+        engine.playAttack();
+
+        assertEquals(0, engine.getCurrentPlayerId());
+        assertEquals(STACKED_ATTACK_FORCED_TURNS, engine.getForcedTurns());
+    }
+
+    private void giveToCurrent(GameEngine engine, CardType type) {
+        engine.getPlayer(engine.getCurrentPlayerId()).addCardToHand(new Card(type));
+    }
+
+    private void clearCardType(Player player, CardType type) {
+        int index = player.getIndexOfCard(type);
+        while (index >= 0) {
+            player.removeCardFromHand(index);
+            index = player.getIndexOfCard(type);
+        }
     }
 }

--- a/src/test/java/domain/GameEngineTest.java
+++ b/src/test/java/domain/GameEngineTest.java
@@ -3,6 +3,7 @@ package domain;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -502,6 +503,39 @@ class GameEngineTest {
             first.removeCardFromHand(0);
         }
         assertEquals(0, engine.getWinnerId());
+    }
+
+    @Test
+    void playNope_clearsLastPlayedCard() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SKIP);
+        engine.playSkip();
+        engine.getPlayer(1).addCardToHand(new Card(CardType.NOPE));
+
+        engine.playNope(1);
+
+        assertNull(engine.getLastPlayedCard());
+    }
+
+    @Test
+    void playNope_nothingToCancel_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.playNope(0));
+        assertEquals("rule.nope.nothingToCancel", ex.getMessage());
+    }
+
+    @Test
+    void playNope_noperLacksNope_throwsIllegalStateException() {
+        GameEngine engine = new GameEngine(MIN_PLAYERS);
+        giveToCurrent(engine, CardType.SKIP);
+        engine.playSkip();
+        clearCardType(engine.getPlayer(1), CardType.NOPE);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> engine.playNope(1));
+        assertEquals("gameEngine.play.notInHand", ex.getMessage());
     }
 
     private void giveToCurrent(GameEngine engine, CardType type) {

--- a/src/test/java/domain/RuleManagerTest.java
+++ b/src/test/java/domain/RuleManagerTest.java
@@ -1,0 +1,100 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class RuleManagerTest {
+
+    private final RuleManager ruleManager = new RuleManager();
+
+    @Test
+    void requirePlayable_normalCard_returnsNormally() {
+        assertDoesNotThrow(() -> ruleManager.requirePlayable(CardType.SKIP));
+    }
+
+    @Test
+    void requirePlayable_defuse_throwsIllegalArgumentException() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> ruleManager.requirePlayable(CardType.DEFUSE));
+        assertEquals("rule.play.cannotPlayDirectly", ex.getMessage());
+    }
+
+    @Test
+    void requirePlayable_explodingKitten_throwsIllegalArgumentException() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> ruleManager.requirePlayable(CardType.EXPLODING_KITTEN));
+        assertEquals("rule.play.cannotPlayDirectly", ex.getMessage());
+    }
+
+    @Test
+    void requireValidTarget_distinctLivingTarget_returnsNormally() {
+        Player actor = new Player(0);
+        Player target = new Player(1);
+        assertDoesNotThrow(() -> ruleManager.requireValidTarget(actor, target));
+    }
+
+    @Test
+    void requireValidTarget_self_throwsIllegalArgumentException() {
+        Player actor = new Player(0);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> ruleManager.requireValidTarget(actor, actor));
+        assertEquals("rule.target.invalid", ex.getMessage());
+    }
+
+    @Test
+    void requireValidTarget_deadTarget_throwsIllegalArgumentException() {
+        Player actor = new Player(0);
+        Player target = new Player(1);
+        target.markDead();
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> ruleManager.requireValidTarget(actor, target));
+        assertEquals("rule.target.invalid", ex.getMessage());
+    }
+
+    @Test
+    void requireCatPair_twoCatCards_returnsNormally() {
+        Player actor = new Player(0);
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        assertDoesNotThrow(() -> ruleManager.requireCatPair(actor));
+    }
+
+    @Test
+    void requireCatPair_noCatCards_throwsIllegalStateException() {
+        Player actor = new Player(0);
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> ruleManager.requireCatPair(actor));
+        assertEquals("rule.catPair.needTwo", ex.getMessage());
+    }
+
+    @Test
+    void requireCatPair_oneCatCard_throwsIllegalStateException() {
+        Player actor = new Player(0);
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> ruleManager.requireCatPair(actor));
+        assertEquals("rule.catPair.needTwo", ex.getMessage());
+    }
+
+    @Test
+    void requireSomethingToNope_nonNullLastCard_returnsNormally() {
+        assertDoesNotThrow(() -> ruleManager.requireSomethingToNope(CardType.ATTACK));
+    }
+
+    @Test
+    void requireSomethingToNope_null_throwsIllegalStateException() {
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> ruleManager.requireSomethingToNope(null));
+        assertEquals("rule.nope.nothingToCancel", ex.getMessage());
+    }
+}

--- a/src/test/java/domain/RuleManagerTest.java
+++ b/src/test/java/domain/RuleManagerTest.java
@@ -86,6 +86,15 @@ class RuleManagerTest {
     }
 
     @Test
+    void requireCatPair_threeCatCards_returnsNormally() {
+        Player actor = new Player(0);
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        actor.addCardToHand(new Card(CardType.CAT_CARDS));
+        assertDoesNotThrow(() -> ruleManager.requireCatPair(actor));
+    }
+
+    @Test
     void requireSomethingToNope_nonNullLastCard_returnsNormally() {
         assertDoesNotThrow(() -> ruleManager.requireSomethingToNope(CardType.ATTACK));
     }


### PR DESCRIPTION
## Summary
Finalizes the Exploding Kittens game logic into a fully playable loop, adds two new card types, and a second win condition. All player decisions arrive as explicit method parameters (no I/O in the domain), so everything is deterministic and unit-tested. Built per the design in `docs/plans/2026-06-01-game-loop-design.md`.

## What's added

**New card types** — `REVERSE` and `TARGETED_ATTACK`, dealt from the deck (deck size 56 → 63; setup draw-pile constants and Vincent's `DeckTest`/`bva-Deck.md` recomputed accordingly: 50 cards for 2 players, 38 for 5).

**`RuleManager`** (pure validation): `requirePlayable`, `requireValidTarget`, `requireCatPair`, `requireSomethingToNope`.

**`ActionController`** (deck/player effects, injected `Random` for deterministic cat-steal): `shuffleDeck`, `peekTopThree`, `reverseDirection`, `giveCard`, `stealRandomCard`.

**`GameEngine`** turn loop:
- Turn-state: `forcedTurns`, `lastPlayedCard`; helpers advance past dead players.
- Plays: `playSkip`, `playShuffle`, `playSeeTheFuture`, `playReverse`, `playAttack`, `playTargetedAttack`, `playFavor`, `playCatPair`, `playNope`.
- Draw resolution: `defuseDrawnKitten`, `explodeCurrentPlayer`.
- **Win conditions**: `isGameOver` / `getWinnerId` — last player standing, plus draw-pile-exhausted (most cards in hand; ties broken by lowest player id).

`playReverse` exercises `TurnTracker.changeCurrentDirection`.

## Standards compliance
- **§1 design doc** — every new class/method documented in `design-doc.md` before code.
- **§2 BVA** — `bva-RuleManager.md`, `bva-ActionController.md`, and `bva-GameEngine.md` (methods 10–22) authored with boundary/edge cases; `bva-Card.md` / `bva-Deck.md` updated for the new cards and size.
- **§3 TDD** — per-method Red→Green commits; BVA `Implemented?` flips with each green test.
- **§4 sole authorship** — all commits Jixin (Kevin) Yan, no co-author trailers.
- **§6 Clean Code** — `final` classes, named constants (no magic numbers), extracted exception keys.
- **§7 i18n** — all new messages keyed in both `message_en.properties` and `message_zh.properties` (`rule.*`, `gameEngine.*`).
- **Use cases** — added player-facing flows UC9–16 (skip, shuffle, reverse, targeted attack, favor, cat pair, nope, exhausted-pile ending) alongside the merged UC8.

## Test plan
- [x] `./gradlew build` green (checkstyle + spotbugs + tests, strict mode) after rebase onto main
- [x] New tests: RuleManager (11), ActionController (11), GameEngine play/win (≈25)
- [ ] CI on this PR
